### PR TITLE
YtTableSparkSettings.StringToUtf8

### DIFF
--- a/data-source-extended/src/main/scala/org/apache/spark/sql/catalyst/catalog/YTsaurusExternalCatalog.scala
+++ b/data-source-extended/src/main/scala/org/apache/spark/sql/catalyst/catalog/YTsaurusExternalCatalog.scala
@@ -9,7 +9,7 @@ import org.apache.spark.sql.types.StructType
 import tech.ytsaurus.spyt.fs.YtClientConfigurationConverter.ytClientConfiguration
 import tech.ytsaurus.spyt.fs.path.YPathEnriched
 import tech.ytsaurus.spyt.serializers.SchemaConverter.{Sorted, Unordered}
-import tech.ytsaurus.spyt.serializers.{SchemaConverter, SchemaConverterConfig}
+import tech.ytsaurus.spyt.serializers.{SchemaConverter, SchemaConverterConfig, WriteSchemaConverter}
 import tech.ytsaurus.spyt.wrapper.YtWrapper
 import tech.ytsaurus.spyt.wrapper.client.YtClientProvider
 import tech.ytsaurus.spyt.wrapper.table.BaseYtTableSettings
@@ -68,7 +68,7 @@ class YTsaurusExternalCatalog(conf: SparkConf, hadoopConf: Configuration)
       val yt = YtClientProvider.ytClientWithProxy(ytConf, path.cluster, idPrefix)
       if (!YtWrapper.exists(path.toStringYPath)(yt)) {
         val extraProperties = tableDefinition.properties.mapValues(YTreeTextSerializer.deserialize)
-        val tableSchema = SchemaConverter.tableSchema(tableDefinition.schema, getSortOption(extraProperties))
+        val tableSchema = WriteSchemaConverter().tableSchema(tableDefinition.schema, getSortOption(extraProperties))
         val settings = new BaseYtTableSettings(tableSchema, extraProperties.filterKeys(!excludeKeys.contains(_)))
         YtWrapper.createTable(path.toStringYPath, settings)(yt)
       } else {

--- a/data-source-extended/src/main/scala/org/apache/spark/sql/catalyst/catalog/YTsaurusExternalCatalog.scala
+++ b/data-source-extended/src/main/scala/org/apache/spark/sql/catalyst/catalog/YTsaurusExternalCatalog.scala
@@ -68,7 +68,7 @@ class YTsaurusExternalCatalog(conf: SparkConf, hadoopConf: Configuration)
       val yt = YtClientProvider.ytClientWithProxy(ytConf, path.cluster, idPrefix)
       if (!YtWrapper.exists(path.toStringYPath)(yt)) {
         val extraProperties = tableDefinition.properties.mapValues(YTreeTextSerializer.deserialize)
-        val tableSchema = WriteSchemaConverter().tableSchema(tableDefinition.schema, getSortOption(extraProperties))
+        val tableSchema = new WriteSchemaConverter().tableSchema(tableDefinition.schema, getSortOption(extraProperties))
         val settings = new BaseYtTableSettings(tableSchema, extraProperties.filterKeys(!excludeKeys.contains(_)))
         YtWrapper.createTable(path.toStringYPath, settings)(yt)
       } else {

--- a/data-source-extended/src/test/scala/tech/ytsaurus/spyt/serializers/ExtendedSchemaConverterTest.scala
+++ b/data-source-extended/src/test/scala/tech/ytsaurus/spyt/serializers/ExtendedSchemaConverterTest.scala
@@ -162,7 +162,7 @@ class ExtendedSchemaConverterTest extends AnyFlatSpec with Matchers
       YTree.builder.beginMap.key("name").value(name).key("type").value(t)
         .key("required").value(false).buildMap
     }
-    val res = WriteSchemaConverter(Map.empty, typeV3Format = false).ytLogicalSchema(extendedSparkSchema, Unordered)
+    val res = new WriteSchemaConverter(Map.empty, typeV3Format = false).ytLogicalSchema(extendedSparkSchema, Unordered)
     res shouldBe YTree.builder
       .beginAttributes
       .key("strict").value(true)

--- a/data-source-extended/src/test/scala/tech/ytsaurus/spyt/serializers/ExtendedSchemaConverterTest.scala
+++ b/data-source-extended/src/test/scala/tech/ytsaurus/spyt/serializers/ExtendedSchemaConverterTest.scala
@@ -162,7 +162,7 @@ class ExtendedSchemaConverterTest extends AnyFlatSpec with Matchers
       YTree.builder.beginMap.key("name").value(name).key("type").value(t)
         .key("required").value(false).buildMap
     }
-    val res = new WriteSchemaConverter(Map.empty, typeV3Format = false).ytLogicalSchema(extendedSparkSchema, Unordered)
+    val res = new WriteSchemaConverter().ytLogicalSchema(extendedSparkSchema, Unordered)
     res shouldBe YTree.builder
       .beginAttributes
       .key("strict").value(true)

--- a/data-source-extended/src/test/scala/tech/ytsaurus/spyt/serializers/ExtendedSchemaConverterTest.scala
+++ b/data-source-extended/src/test/scala/tech/ytsaurus/spyt/serializers/ExtendedSchemaConverterTest.scala
@@ -127,7 +127,7 @@ class ExtendedSchemaConverterTest extends AnyFlatSpec with Matchers
   }
 
   it should "convert spark schema to yt one with parsing type v3" in {
-    val res = TableSchema.fromYTree(WriteSchemaConverter(Map.empty, typeV3Format = true).ytLogicalSchema(extendedSparkSchema, Unordered))
+    val res = TableSchema.fromYTree(new WriteSchemaConverter(typeV3Format = true).ytLogicalSchema(extendedSparkSchema, Unordered))
     res shouldBe TableSchema.builder().setUniqueKeys(false)
       .addValue("Null", TiType.nullType())
       .addValue("Long", TiType.int64())

--- a/data-source-extended/src/test/scala/tech/ytsaurus/spyt/serializers/ExtendedSchemaConverterTest.scala
+++ b/data-source-extended/src/test/scala/tech/ytsaurus/spyt/serializers/ExtendedSchemaConverterTest.scala
@@ -8,8 +8,7 @@ import org.scalatest.matchers.should.Matchers
 import tech.ytsaurus.core.tables.{ColumnValueType, TableSchema}
 import tech.ytsaurus.spyt.{SchemaTestUtils, YtReader}
 import tech.ytsaurus.spyt.format.conf.SparkYtConfiguration.Read.TypeV3
-import tech.ytsaurus.spyt.serializers.SchemaConverter.{Unordered, ytLogicalSchema}
-import tech.ytsaurus.spyt.serializers.SchemaConverterTest.structField
+import tech.ytsaurus.spyt.serializers.SchemaConverter.Unordered
 import tech.ytsaurus.spyt.test.{LocalSpark, TestUtils, TmpDir}
 import tech.ytsaurus.typeinfo.StructType.Member
 import tech.ytsaurus.typeinfo.TiType
@@ -128,7 +127,7 @@ class ExtendedSchemaConverterTest extends AnyFlatSpec with Matchers
   }
 
   it should "convert spark schema to yt one with parsing type v3" in {
-    val res = TableSchema.fromYTree(ytLogicalSchema(extendedSparkSchema, Unordered, Map.empty, typeV3Format = true))
+    val res = TableSchema.fromYTree(WriteSchemaConverter(Map.empty, typeV3Format = true).ytLogicalSchema(extendedSparkSchema, Unordered))
     res shouldBe TableSchema.builder().setUniqueKeys(false)
       .addValue("Null", TiType.nullType())
       .addValue("Long", TiType.int64())
@@ -163,7 +162,7 @@ class ExtendedSchemaConverterTest extends AnyFlatSpec with Matchers
       YTree.builder.beginMap.key("name").value(name).key("type").value(t)
         .key("required").value(false).buildMap
     }
-    val res = ytLogicalSchema(extendedSparkSchema, Unordered, Map.empty, typeV3Format = false)
+    val res = WriteSchemaConverter(Map.empty, typeV3Format = false).ytLogicalSchema(extendedSparkSchema, Unordered)
     res shouldBe YTree.builder
       .beginAttributes
       .key("strict").value(true)

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/format/YtDynamicTableWriter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/format/YtDynamicTableWriter.scala
@@ -26,7 +26,7 @@ class YtDynamicTableWriter(richPath: YPathEnriched,
 
   override val path: String = richPath.toStringPath
 
-  private val writeSchemaConverter = new WriteSchemaConverter(options)
+  private val writeSchemaConverter = WriteSchemaConverter(options)
 
   private val tableSchema = writeSchemaConverter.tableSchema(schema, Unordered)
   private var count = 0

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/format/YtDynamicTableWriter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/format/YtDynamicTableWriter.scala
@@ -10,11 +10,9 @@ import org.slf4j.LoggerFactory
 import tech.ytsaurus.client.CompoundClient
 import tech.ytsaurus.client.request.ModifyRowsRequest
 import tech.ytsaurus.spyt.format.conf.SparkYtWriteConfiguration
-import tech.ytsaurus.spyt.format.conf.YtTableSparkSettings.{WriteSchemaHint, WriteTypeV3}
-import tech.ytsaurus.spyt.fs.conf._
 import tech.ytsaurus.spyt.fs.path.YPathEnriched
-import tech.ytsaurus.spyt.serializers.SchemaConverter
 import tech.ytsaurus.spyt.serializers.SchemaConverter.Unordered
+import tech.ytsaurus.spyt.serializers.WriteSchemaConverter
 import tech.ytsaurus.spyt.wrapper.YtWrapper
 
 import scala.collection.JavaConverters._
@@ -28,10 +26,9 @@ class YtDynamicTableWriter(richPath: YPathEnriched,
 
   override val path: String = richPath.toStringPath
 
-  private val schemaHint = options.ytConf(WriteSchemaHint)
-  private val typeV3Format = options.ytConf(WriteTypeV3)
+  private val writeSchemaConverter = new WriteSchemaConverter(options)
 
-  private val tableSchema = SchemaConverter.tableSchema(schema, Unordered, schemaHint, typeV3Format)
+  private val tableSchema = writeSchemaConverter.tableSchema(schema, Unordered)
   private var count = 0
   private var modifyRowsRequestBuilder: ModifyRowsRequest.Builder = _
 

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/format/YtOutputWriter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/format/YtOutputWriter.scala
@@ -153,7 +153,7 @@ class YtOutputWriter(richPath: YPathEnriched,
     log.debugLazy(s"Initialize new write: $appendPath, transaction: $transactionGuid")
     val request = WriteTable.builder[InternalRow]()
       .setPath(appendPath)
-      .setSerializationContext(new WriteSerializationContext(new InternalRowSerializer(schema, new WriteSchemaConverter(options))))
+      .setSerializationContext(new WriteSerializationContext(new InternalRowSerializer(schema, WriteSchemaConverter(options))))
       .setTransactionalOptions(new TransactionalOptions(GUID.valueOf(transactionGuid)))
       .setNeedRetries(false)
       .build()

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/format/YtOutputWriterFactory.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/format/YtOutputWriterFactory.scala
@@ -48,7 +48,7 @@ object YtOutputWriterFactory {
 
     val updatedOptions = addWriteOptions(options, writeConfiguration)
     YtTableSparkSettings.serialize(
-      updatedOptions, new WriteSchemaConverter(updatedOptions).ytLogicalTypeStruct(dataSchema), jobConfiguration
+      updatedOptions, WriteSchemaConverter(updatedOptions).ytLogicalTypeStruct(dataSchema), jobConfiguration
     )
 
     new YtOutputWriterFactory(ytClientConf, writeConfiguration, updatedOptions)

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/format/YtOutputWriterFactory.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/format/YtOutputWriterFactory.scala
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory
 import tech.ytsaurus.client.CompoundClient
 import tech.ytsaurus.spyt.format.conf.{SparkYtWriteConfiguration, YtTableSparkSettings}
 import tech.ytsaurus.spyt.fs.path.YPathEnriched
-import tech.ytsaurus.spyt.serializers.SchemaConverter
+import tech.ytsaurus.spyt.serializers.{SchemaConverter, WriteSchemaConverter}
 import tech.ytsaurus.spyt.wrapper.YtWrapper
 import tech.ytsaurus.spyt.wrapper.client.{YtClientConfiguration, YtClientProvider}
 
@@ -47,7 +47,9 @@ object YtOutputWriterFactory {
     SchemaConverter.checkSchema(dataSchema, options)
 
     val updatedOptions = addWriteOptions(options, writeConfiguration)
-    YtTableSparkSettings.serialize(updatedOptions, dataSchema, jobConfiguration)
+    YtTableSparkSettings.serialize(
+      updatedOptions, new WriteSchemaConverter(updatedOptions).ytLogicalTypeStruct(dataSchema), jobConfiguration
+    )
 
     new YtOutputWriterFactory(ytClientConf, writeConfiguration, updatedOptions)
   }

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/format/conf/YtTableSparkSettings.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/format/conf/YtTableSparkSettings.scala
@@ -24,7 +24,7 @@ case class YtTableSparkSettings(configuration: Configuration) extends YtTableSet
     if (keys.nonEmpty) Sorted(keys, uniqueKeys) else Unordered
   }
 
-  private def writeSchemaConverter = new WriteSchemaConverter(configuration)
+  private def writeSchemaConverter = WriteSchemaConverter(configuration)
 
   private def schema: StructType = configuration.ytConf(Schema).sparkType
 

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/format/conf/YtTableSparkSettings.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/format/conf/YtTableSparkSettings.scala
@@ -1,14 +1,13 @@
 package tech.ytsaurus.spyt.format.conf
 
 import org.apache.hadoop.conf.Configuration
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{DataType, StructType}
 import tech.ytsaurus.spyt.fs.conf._
 import tech.ytsaurus.spyt.serializers.SchemaConverter.{SortOption, Sorted, Unordered}
-import tech.ytsaurus.spyt.serializers.SchemaConverter
+import tech.ytsaurus.spyt.serializers.{SchemaConverter, WriteSchemaConverter, YtLogicalType}
 import tech.ytsaurus.spyt.wrapper.table.YtTableSettings
 import tech.ytsaurus.spyt.fs.conf.ConfigEntry
 import tech.ytsaurus.spyt.serializers.YtLogicalTypeSerializer.{deserializeTypeV3, serializeTypeV3}
-import tech.ytsaurus.spyt.serializers.YtLogicalType
 import tech.ytsaurus.ysontree.YTreeNode
 import tech.ytsaurus.ysontree.YTreeTextSerializer
 
@@ -25,14 +24,11 @@ case class YtTableSparkSettings(configuration: Configuration) extends YtTableSet
     if (keys.nonEmpty) Sorted(keys, uniqueKeys) else Unordered
   }
 
-  private def writeSchemaHints: Map[String, YtLogicalType] = configuration.ytConf(WriteSchemaHint)
+  private def writeSchemaConverter = new WriteSchemaConverter(configuration)
 
-  private def typeV3Format: Boolean = configuration.ytConf(WriteTypeV3)
+  private def schema: StructType = configuration.ytConf(Schema).sparkType
 
-  private def schema: StructType = configuration.ytConf(Schema)
-
-  override def ytSchema: YTreeNode = SchemaConverter.ytLogicalSchema(
-    schema, sortOption, writeSchemaHints, typeV3Format)
+  override def ytSchema: YTreeNode = writeSchemaConverter.ytLogicalSchema(schema, sortOption)
 
   override def optionsAny: Map[String, Any] = {
     val optionsKeys = configuration.ytConf(Options)
@@ -46,10 +42,12 @@ object YtTableSparkSettings {
   import ConfigEntry.implicits._
   import ConfigEntry.{fromJsonTyped, toJsonTyped}
 
-  implicit val structTypeAdapter: ValueAdapter[StructType] = new ValueAdapter[StructType] {
-    override def get(value: String): StructType = SchemaConverter.stringToSparkType(value).asInstanceOf[StructType]
+  implicit val structTypeAdapter: ValueAdapter[YtLogicalType.Struct] = new ValueAdapter[YtLogicalType.Struct] {
+    override def get(value: String): YtLogicalType.Struct =
+      deserializeTypeV3(YTreeTextSerializer.deserialize(value)).asInstanceOf[YtLogicalType.Struct]
 
-    override def set(value: StructType): String = SchemaConverter.sparkTypeToString(value)
+    override def set(value: YtLogicalType.Struct): String =
+      YTreeTextSerializer.serialize(serializeTypeV3(value, innerForm = true))
   }
 
   implicit val logicalTypeMapAdapter: ValueAdapter[Map[String, YtLogicalType]] = new ValueAdapter[Map[String, YtLogicalType]] {
@@ -88,11 +86,13 @@ object YtTableSparkSettings {
 
   case object WriteSchemaHint extends ConfigEntry[Map[String, YtLogicalType]]("write_schema_hint", Some(Map.empty))
 
-  case object Schema extends ConfigEntry[StructType]("schema")
+  case object Schema extends ConfigEntry[YtLogicalType.Struct]("schema")
 
   case object WriteTransaction extends ConfigEntry[String]("write_transaction")
 
   case object WriteTypeV3 extends ConfigEntry[Boolean]("write_type_v3", Some(false))
+
+  case object StringToUtf8 extends ConfigEntry[Boolean]("string_to_utf8", Some(false))
 
   case object NullTypeAllowed extends ConfigEntry[Boolean]("null_type_allowed", Some(false))
 
@@ -130,7 +130,7 @@ object YtTableSparkSettings {
     YtTableSparkSettings(configuration)
   }
 
-  def serialize(options: Map[String, String], schema: StructType, configuration: Configuration): Unit = {
+  def serialize(options: Map[String, String], schema: YtLogicalType.Struct, configuration: Configuration): Unit = {
     options.foreach { case (key, value) =>
       configuration.setYtConf(key, value)
     }

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/GenericRowSerializer.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/GenericRowSerializer.scala
@@ -13,7 +13,7 @@ import java.util.Base64
 
 // TODO(alex-shishkin): Supported type v1 only
 class GenericRowSerializer(schema: StructType) {
-  private val tableSchema = WriteSchemaConverter(hint = Map.empty).tableSchema(schema, Unordered)
+  private val tableSchema = new WriteSchemaConverter(hint = Map.empty).tableSchema(schema, Unordered)
 
   private def boxValue(i: Int, value: Any): UnversionedValue = {
     new UnversionedValue(i, tableSchema.getColumnType(i), false, value)

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/GenericRowSerializer.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/GenericRowSerializer.scala
@@ -13,7 +13,7 @@ import java.util.Base64
 
 // TODO(alex-shishkin): Supported type v1 only
 class GenericRowSerializer(schema: StructType) {
-  private val tableSchema = SchemaConverter.tableSchema(schema, Unordered, Map.empty)
+  private val tableSchema = WriteSchemaConverter(hint = Map.empty).tableSchema(schema, Unordered)
 
   private def boxValue(i: Int, value: Any): UnversionedValue = {
     new UnversionedValue(i, tableSchema.getColumnType(i), false, value)

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/GenericRowSerializer.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/GenericRowSerializer.scala
@@ -13,7 +13,7 @@ import java.util.Base64
 
 // TODO(alex-shishkin): Supported type v1 only
 class GenericRowSerializer(schema: StructType) {
-  private val tableSchema = new WriteSchemaConverter(hint = Map.empty).tableSchema(schema, Unordered)
+  private val tableSchema = new WriteSchemaConverter().tableSchema(schema, Unordered)
 
   private def boxValue(i: Int, value: Any): UnversionedValue = {
     new UnversionedValue(i, tableSchema.getColumnType(i), false, value)

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/InternalRowSerializer.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/InternalRowSerializer.scala
@@ -138,7 +138,7 @@ object InternalRowSerializer {
                   schemaHint: Map[String, YtLogicalType],
                   filters: Array[Filter] = Array.empty,
                   typeV3Format: Boolean = false): InternalRowSerializer = {
-    deserializers.get().getOrElseUpdate(schema, new InternalRowSerializer(schema, WriteSchemaConverter(schemaHint, typeV3Format)))
+    deserializers.get().getOrElseUpdate(schema, new InternalRowSerializer(schema, new WriteSchemaConverter(schemaHint, typeV3Format)))
   }
 
   final def writeRows(writer: TableWriter[InternalRow],

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/InternalRowSerializer.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/InternalRowSerializer.scala
@@ -10,6 +10,7 @@ import org.slf4j.LoggerFactory
 import tech.ytsaurus.client.TableWriter
 import tech.ytsaurus.client.rows.{WireProtocolWriteable, WireRowSerializer}
 import tech.ytsaurus.core.tables.{ColumnValueType, TableSchema}
+import tech.ytsaurus.spyt.format.conf.YtTableSparkSettings.{WriteSchemaHint, WriteTypeV3}
 import tech.ytsaurus.spyt.serialization.YsonEncoder
 import tech.ytsaurus.spyt.serializers.InternalRowSerializer._
 import tech.ytsaurus.spyt.serializers.SchemaConverter.{Unordered, decimalToBinary}
@@ -23,19 +24,18 @@ import scala.collection.mutable
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
-class InternalRowSerializer(schema: StructType, schemaHint: Map[String, YtLogicalType],
-                            typeV3Format: Boolean = false) extends WireRowSerializer[InternalRow] with LogLazy {
+class InternalRowSerializer(schema: StructType, writeSchemaConverter: WriteSchemaConverter) extends WireRowSerializer[InternalRow] with LogLazy {
 
   private val log = LoggerFactory.getLogger(getClass)
 
-  private val tableSchema = SchemaConverter.tableSchema(schema, Unordered, schemaHint, typeV3Format)
+  private val tableSchema = writeSchemaConverter.tableSchema(schema, Unordered)
 
   override def getSchema: TableSchema = tableSchema
 
   private def getColumnType(i: Int): ColumnValueType = {
     def isComposite(t: TiType): Boolean = t.isList || t.isDict || t.isStruct || t.isTuple || t.isVariant
 
-    if (typeV3Format) {
+    if (writeSchemaConverter.typeV3Format) {
       val column = tableSchema.getColumnSchema(i)
       val t = column.getTypeV3
       if (t.isOptional) {
@@ -68,7 +68,7 @@ class InternalRowSerializer(schema: StructType, schemaHint: Map[String, YtLogica
         writeable.writeValueHeader(valueId(i, idMapping), ColumnValueType.NULL, aggregate, 0)
       } else {
         val sparkField = schema(i)
-        val ytFieldHint = if (typeV3Format) Some(tableSchema.getColumnSchema(i).getTypeV3) else None
+        val ytFieldHint = if (writeSchemaConverter.typeV3Format) Some(tableSchema.getColumnSchema(i).getTypeV3) else None
         sparkField.dataType match {
           case BinaryType =>
             writeBytes(writeable, idMapping, aggregate, i, row.getBinary(i), getColumnType)
@@ -76,7 +76,7 @@ class InternalRowSerializer(schema: StructType, schemaHint: Map[String, YtLogica
             writeBytes(writeable, idMapping, aggregate, i, row.getUTF8String(i).getBytes, getColumnType)
           case d: DecimalType =>
             val value = row.getDecimal(i, d.precision, d.scale)
-            if (typeV3Format) {
+            if (writeSchemaConverter.typeV3Format) {
               val binary = decimalToBinary(ytFieldHint, d, value)
               writeBytes(writeable, idMapping, aggregate, i, binary, getColumnType)
             } else {
@@ -99,7 +99,7 @@ class InternalRowSerializer(schema: StructType, schemaHint: Map[String, YtLogica
           case t@(ArrayType(_, _) | StructType(_) | MapType(_, _, _)) =>
             val skipNulls = sparkField.metadata.contains("skipNulls") && sparkField.metadata.getBoolean("skipNulls")
             writeBytes(writeable, idMapping, aggregate, i,
-              YsonEncoder.encode(row.get(i, sparkField.dataType), t, skipNulls, typeV3Format, ytFieldHint),
+              YsonEncoder.encode(row.get(i, sparkField.dataType), t, skipNulls, writeSchemaConverter.typeV3Format, ytFieldHint),
               getColumnType)
           case otherType =>
             val isExtendedType = YTsaurusTypes
@@ -138,7 +138,7 @@ object InternalRowSerializer {
                   schemaHint: Map[String, YtLogicalType],
                   filters: Array[Filter] = Array.empty,
                   typeV3Format: Boolean = false): InternalRowSerializer = {
-    deserializers.get().getOrElseUpdate(schema, new InternalRowSerializer(schema, schemaHint, typeV3Format))
+    deserializers.get().getOrElseUpdate(schema, new InternalRowSerializer(schema, WriteSchemaConverter(schemaHint, typeV3Format)))
   }
 
   final def writeRows(writer: TableWriter[InternalRow],

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/SchemaConverter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/SchemaConverter.scala
@@ -78,7 +78,7 @@ object SchemaConverter {
     val enrichedFields = schema.fields.map { field =>
       // There may be a bug when user explicitly specifies schema for YTsaurus Interval type, which doesn't support
       // arrow yet, in this case we can suggest to use spark.read.disableArrow option
-      if (WriteSchemaConverter().ytLogicalTypeV3(field.dataType).arrowSupported) {
+      if (new WriteSchemaConverter().ytLogicalTypeV3(field.dataType).arrowSupported) {
         val metadataBuilder = new MetadataBuilder()
         metadataBuilder.withMetadata(field.metadata)
         metadataBuilder.putBoolean(MetadataFields.ARROW_SUPPORTED, value = true)

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/SchemaConverter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/SchemaConverter.scala
@@ -1,19 +1,16 @@
 package tech.ytsaurus.spyt.serializers
 
-import org.apache.spark.sql.spyt.types._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.v2.YtTable
 import tech.ytsaurus.core.common.Decimal.textToBinary
-import tech.ytsaurus.core.tables.{ColumnSortOrder, TableSchema}
-import tech.ytsaurus.spyt.common.utils.TypeUtils.{isTuple, isVariant, isVariantOverTuple}
+import tech.ytsaurus.spyt.common.utils.TypeUtils.{isTuple, isVariant}
 import tech.ytsaurus.spyt.format.conf.YtTableSparkSettings.isNullTypeAllowed
 import tech.ytsaurus.spyt.serialization.IndexedDataType
 import tech.ytsaurus.spyt.serialization.IndexedDataType.StructFieldMeta
 import tech.ytsaurus.spyt.serializers.YtLogicalType.getStructField
-import tech.ytsaurus.spyt.serializers.YtLogicalTypeSerializer.{deserializeTypeV3, serializeType, serializeTypeV3}
-import tech.ytsaurus.spyt.types.YTsaurusTypes
+import tech.ytsaurus.spyt.serializers.YtLogicalTypeSerializer.deserializeTypeV3
 import tech.ytsaurus.typeinfo.TiType
-import tech.ytsaurus.ysontree.{YTree, YTreeNode, YTreeTextSerializer}
+import tech.ytsaurus.ysontree.YTreeNode
 
 object SchemaConverter {
   object MetadataFields {
@@ -79,13 +76,12 @@ object SchemaConverter {
 
   def enrichUserProvidedSchema(schema: StructType): StructType = {
     val enrichedFields = schema.fields.map { field =>
-      val ytType = ytLogicalTypeV3(field.dataType)
       // There may be a bug when user explicitly specifies schema for YTsaurus Interval type, which doesn't support
       // arrow yet, in this case we can suggest to use spark.read.disableArrow option
-      if (ytType.arrowSupported) {
+      if (WriteSchemaConverter().ytLogicalTypeV3(field.dataType).arrowSupported) {
         val metadataBuilder = new MetadataBuilder()
         metadataBuilder.withMetadata(field.metadata)
-        metadataBuilder.putBoolean(MetadataFields.ARROW_SUPPORTED, ytType.arrowSupported)
+        metadataBuilder.putBoolean(MetadataFields.ARROW_SUPPORTED, value = true)
         field.copy(metadata = metadataBuilder.build())
       } else {
         field
@@ -170,8 +166,9 @@ object SchemaConverter {
     schema.map(f => (s"${f.name}_hint", f.dataType.json)).toMap
   }
 
-  private def wrapSparkAttributes(inner: YtLogicalType, flag: Boolean,
-                                  metadata: Option[Metadata] = None): YtLogicalType = {
+  def wrapSparkAttributes(
+    inner: YtLogicalType, flag: Boolean, metadata: Option[Metadata] = None,
+  ): YtLogicalType = {
     def wrapNullable(ytType: YtLogicalType): YtLogicalType = {
       val optionalO = metadata.flatMap { m =>
         if (m.contains(MetadataFields.OPTIONAL)) Some(m.getBoolean(MetadataFields.OPTIONAL)) else None
@@ -189,125 +186,8 @@ object SchemaConverter {
     wrapNullable(wrapTagged(inner))
   }
 
-  private def ytLogicalTypeV3Variant(struct: StructType): YtLogicalType = {
-    if (isVariantOverTuple(struct)) {
-      YtLogicalType.VariantOverTuple {
-        struct.fields.map(tF =>
-          (wrapSparkAttributes(ytLogicalTypeV3(tF.dataType), tF.nullable, Some(tF.metadata)), tF.metadata))
-      }
-    } else {
-      YtLogicalType.VariantOverStruct {
-        struct.fields.map(sf => (sf.name.drop(2),
-          wrapSparkAttributes(ytLogicalTypeV3(sf.dataType), sf.nullable, Some(sf.metadata)), sf.metadata))
-      }
-    }
-  }
-
-  def ytLogicalTypeV3(sparkType: DataType): YtLogicalType = sparkType match {
-    case NullType => YtLogicalType.Null
-    case ByteType => YtLogicalType.Int8
-    case ShortType => YtLogicalType.Int16
-    case IntegerType => YtLogicalType.Int32
-    case LongType => YtLogicalType.Int64
-    case StringType => YtLogicalType.String
-    case FloatType => YtLogicalType.Float
-    case DoubleType => YtLogicalType.Double
-    case BooleanType => YtLogicalType.Boolean
-    case d: DecimalType =>
-      val dT = if (d.precision > 35) applyYtLimitToSparkDecimal(d) else d
-      YtLogicalType.Decimal(dT.precision, dT.scale)
-    case aT: ArrayType =>
-      YtLogicalType.Array(wrapSparkAttributes(ytLogicalTypeV3(aT.elementType), aT.containsNull))
-    case sT: StructType if isTuple(sT) =>
-      YtLogicalType.Tuple {
-        sT.fields.map(tF =>
-          (wrapSparkAttributes(ytLogicalTypeV3(tF.dataType), tF.nullable, Some(tF.metadata)), tF.metadata))
-      }
-    case sT: StructType if isVariant(sT) => ytLogicalTypeV3Variant(sT)
-    case sT: StructType =>
-      YtLogicalType.Struct {
-        sT.fields.map(sf => (sf.name,
-          wrapSparkAttributes(ytLogicalTypeV3(sf.dataType), sf.nullable, Some(sf.metadata)), sf.metadata))
-      }
-    case mT: MapType =>
-      YtLogicalType.Dict(
-        ytLogicalTypeV3(mT.keyType),
-        wrapSparkAttributes(ytLogicalTypeV3(mT.valueType), mT.valueContainsNull))
-    case BinaryType => YtLogicalType.Binary
-    case DateType => YtLogicalType.Date
-    case _: DatetimeType => YtLogicalType.Datetime
-    case TimestampType => YtLogicalType.Timestamp
-    case _: Date32Type => YtLogicalType.Date32
-    case _: Datetime64Type => YtLogicalType.Datetime64
-    case _: Timestamp64Type => YtLogicalType.Timestamp64
-    case _: Interval64Type => YtLogicalType.Interval64
-    case otherType => YTsaurusTypes.instance.ytLogicalTypeV3(otherType)
-  }
-
-  private def ytLogicalSchemaImpl(sparkSchema: StructType,
-                                  sortOption: SortOption,
-                                  hint: Map[String, YtLogicalType],
-                                  typeV3Format: Boolean = false,
-                                  isTableSchema: Boolean = false): YTreeNode = {
-    import scala.collection.JavaConverters._
-
-    def serializeColumn(field: StructField, sort: Boolean): YTreeNode = {
-      val builder = YTree.builder
-        .beginMap
-        .key("name").value(field.name)
-      val fieldType = hint.getOrElse(field.name,
-        wrapSparkAttributes(ytLogicalTypeV3(field.dataType), field.nullable, Some(field.metadata)))
-      if (typeV3Format) {
-        builder
-          .key("type_v3").value(serializeTypeV3(fieldType))
-      } else {
-        builder
-          .key("type").value(serializeType(fieldType, isTableSchema))
-          .key("required").value(false)
-      }
-      if (sort) builder.key("sort_order").value(ColumnSortOrder.ASCENDING.getName)
-      builder.buildMap
-    }
-
-    val sortColumnsSet = sortOption.keys.toSet
-    val sortedFields =
-      sortOption.keys
-        .map(sparkSchema.apply)
-        .map(f => serializeColumn(f, sort = true)
-        ) ++ sparkSchema
-        .filter(f => !sortColumnsSet.contains(f.name))
-        .map(f => serializeColumn(f, sort = false))
-
-    YTree.builder
-      .beginAttributes
-      .key("strict").value(true)
-      .key("unique_keys").value(sortOption.uniqueKeys)
-      .endAttributes
-      .value(sortedFields.asJava)
-      .build
-  }
-
-  def ytLogicalSchema(sparkSchema: StructType, sortOption: SortOption = Unordered,
-                      hint: Map[String, YtLogicalType] = Map.empty, typeV3Format: Boolean = false): YTreeNode = {
-    ytLogicalSchemaImpl(sparkSchema, sortOption, hint, typeV3Format)
-  }
-
-  def tableSchema(sparkSchema: StructType, sortOption: SortOption = Unordered,
-                  hint: Map[String, YtLogicalType] = Map.empty, typeV3Format: Boolean = false): TableSchema = {
-    TableSchema.fromYTree(ytLogicalSchemaImpl(sparkSchema, sortOption,
-      hint, typeV3Format, isTableSchema = true))
-  }
-
   def sparkTypeV1(sType: String): YtLogicalType = {
     YtLogicalType.fromName(sType)
-  }
-
-  def stringToSparkType(sType: String): DataType = {
-    deserializeTypeV3(YTreeTextSerializer.deserialize(sType)).sparkType
-  }
-
-  def sparkTypeToString(sparkType: DataType): String = {
-    YTreeTextSerializer.serialize(serializeTypeV3(ytLogicalTypeV3(sparkType), innerForm = true))
   }
 
   def checkSchema(schema: StructType, options: Map[String, String]): Unit = {

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/WriteSchemaConverter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/WriteSchemaConverter.scala
@@ -13,9 +13,9 @@ import tech.ytsaurus.spyt.types.YTsaurusTypes
 import tech.ytsaurus.ysontree.{YTree, YTreeNode}
 
 class WriteSchemaConverter(
-  hint: Map[String, YtLogicalType] = Map.empty,
-  typeV3Format: Boolean = false,
-  stringToUtf8: Boolean = false,
+  val hint: Map[String, YtLogicalType] = Map.empty,
+  val typeV3Format: Boolean = false,
+  val stringToUtf8: Boolean = false,
 ) {
   private def ytLogicalTypeV3Variant(struct: StructType): YtLogicalType = {
     if (isVariantOverTuple(struct)) {

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/WriteSchemaConverter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/WriteSchemaConverter.scala
@@ -1,0 +1,137 @@
+package tech.ytsaurus.spyt.serializers
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.sql.spyt.types.{Date32Type, Datetime64Type, DatetimeType, Interval64Type, Timestamp64Type}
+import org.apache.spark.sql.types._
+import tech.ytsaurus.core.tables.{ColumnSortOrder, TableSchema}
+import tech.ytsaurus.spyt.common.utils.TypeUtils.{isTuple, isVariant, isVariantOverTuple}
+import tech.ytsaurus.spyt.format.conf.YtTableSparkSettings.{StringToUtf8, WriteSchemaHint, WriteTypeV3}
+import tech.ytsaurus.spyt.fs.conf.{OptionsConf, SparkYtHadoopConfiguration}
+import tech.ytsaurus.spyt.serializers.SchemaConverter.{SortOption, Unordered, applyYtLimitToSparkDecimal, wrapSparkAttributes}
+import tech.ytsaurus.spyt.serializers.YtLogicalTypeSerializer.{serializeType, serializeTypeV3}
+import tech.ytsaurus.spyt.types.YTsaurusTypes
+import tech.ytsaurus.ysontree.{YTree, YTreeNode}
+
+case class WriteSchemaConverter(
+  hint: Map[String, YtLogicalType] = Map.empty,
+  typeV3Format: Boolean = false,
+  stringToUtf8: Boolean = false,
+) {
+  def this(options: Map[String, String]) = this(
+    options.ytConf(WriteSchemaHint),
+    options.ytConf(WriteTypeV3),
+    options.ytConf(StringToUtf8),
+  )
+
+  def this(configuration: Configuration) = this(
+    configuration.ytConf(WriteSchemaHint),
+    configuration.ytConf(WriteTypeV3),
+    configuration.ytConf(StringToUtf8),
+  )
+
+  private def ytLogicalTypeV3Variant(struct: StructType): YtLogicalType = {
+    if (isVariantOverTuple(struct)) {
+      YtLogicalType.VariantOverTuple {
+        struct.fields.map(tF =>
+          (wrapSparkAttributes(ytLogicalTypeV3(tF.dataType), tF.nullable, Some(tF.metadata)), tF.metadata))
+      }
+    } else {
+      YtLogicalType.VariantOverStruct {
+        struct.fields.map(sf => (sf.name.drop(2),
+          wrapSparkAttributes(ytLogicalTypeV3(sf.dataType), sf.nullable, Some(sf.metadata)), sf.metadata))
+      }
+    }
+  }
+
+  def ytLogicalTypeStruct(structType: StructType): YtLogicalType.Struct = YtLogicalType.Struct {
+    structType.fields.map(sf => (sf.name,
+      wrapSparkAttributes(ytLogicalTypeV3(sf.dataType), sf.nullable, Some(sf.metadata)), sf.metadata))
+  }
+
+  def ytLogicalTypeV3(sparkType: DataType): YtLogicalType = sparkType match {
+    case NullType => YtLogicalType.Null
+    case ByteType => YtLogicalType.Int8
+    case ShortType => YtLogicalType.Int16
+    case IntegerType => YtLogicalType.Int32
+    case LongType => YtLogicalType.Int64
+    case StringType => if (stringToUtf8) YtLogicalType.Utf8 else YtLogicalType.String
+    case FloatType => YtLogicalType.Float
+    case DoubleType => YtLogicalType.Double
+    case BooleanType => YtLogicalType.Boolean
+    case d: DecimalType =>
+      val dT = if (d.precision > 35) applyYtLimitToSparkDecimal(d) else d
+      YtLogicalType.Decimal(dT.precision, dT.scale)
+    case aT: ArrayType =>
+      YtLogicalType.Array(wrapSparkAttributes(ytLogicalTypeV3(aT.elementType), aT.containsNull))
+    case sT: StructType if isTuple(sT) =>
+      YtLogicalType.Tuple {
+        sT.fields.map(tF =>
+          (wrapSparkAttributes(ytLogicalTypeV3(tF.dataType), tF.nullable, Some(tF.metadata)), tF.metadata))
+      }
+    case sT: StructType if isVariant(sT) => ytLogicalTypeV3Variant(sT)
+    case sT: StructType => ytLogicalTypeStruct(sT)
+    case mT: MapType =>
+      YtLogicalType.Dict(
+        ytLogicalTypeV3(mT.keyType),
+        wrapSparkAttributes(ytLogicalTypeV3(mT.valueType), mT.valueContainsNull))
+    case BinaryType => YtLogicalType.Binary
+    case DateType => YtLogicalType.Date
+    case _: DatetimeType => YtLogicalType.Datetime
+    case TimestampType => YtLogicalType.Timestamp
+    case _: Date32Type => YtLogicalType.Date32
+    case _: Datetime64Type => YtLogicalType.Datetime64
+    case _: Timestamp64Type => YtLogicalType.Timestamp64
+    case _: Interval64Type => YtLogicalType.Interval64
+    case otherType => YTsaurusTypes.instance.ytLogicalTypeV3(otherType)
+  }
+
+  private def ytLogicalSchemaImpl(sparkSchema: StructType,
+                                  sortOption: SortOption,
+                                  isTableSchema: Boolean = false): YTreeNode = {
+    import scala.collection.JavaConverters._
+
+    def serializeColumn(field: StructField, sort: Boolean): YTreeNode = {
+      val builder = YTree.builder
+        .beginMap
+        .key("name").value(field.name)
+      val fieldType = hint.getOrElse(field.name,
+        wrapSparkAttributes(ytLogicalTypeV3(field.dataType), field.nullable, Some(field.metadata)))
+      if (typeV3Format) {
+        builder
+          .key("type_v3").value(serializeTypeV3(fieldType))
+      } else {
+        builder
+          .key("type").value(serializeType(fieldType, isTableSchema))
+          .key("required").value(false)
+      }
+      if (sort) builder.key("sort_order").value(ColumnSortOrder.ASCENDING.getName)
+      builder.buildMap
+    }
+
+    val sortColumnsSet = sortOption.keys.toSet
+    val sortedFields =
+      sortOption.keys
+        .map(sparkSchema.apply)
+        .map(f => serializeColumn(f, sort = true)
+        ) ++ sparkSchema
+        .filter(f => !sortColumnsSet.contains(f.name))
+        .map(f => serializeColumn(f, sort = false))
+
+    YTree.builder
+      .beginAttributes
+      .key("strict").value(true)
+      .key("unique_keys").value(sortOption.uniqueKeys)
+      .endAttributes
+      .value(sortedFields.asJava)
+      .build
+  }
+
+  def ytLogicalSchema(sparkSchema: StructType, sortOption: SortOption = Unordered): YTreeNode = {
+    ytLogicalSchemaImpl(sparkSchema, sortOption)
+  }
+
+  def tableSchema(sparkSchema: StructType, sortOption: SortOption = Unordered): TableSchema = {
+    TableSchema.fromYTree(ytLogicalSchemaImpl(sparkSchema, sortOption,
+      isTableSchema = true))
+  }
+}

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/WriteSchemaConverter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/WriteSchemaConverter.scala
@@ -17,18 +17,6 @@ class WriteSchemaConverter(
   typeV3Format: Boolean = false,
   stringToUtf8: Boolean = false,
 ) {
-  def this(options: Map[String, String]) = this(
-    options.ytConf(WriteSchemaHint),
-    options.ytConf(WriteTypeV3),
-    options.ytConf(StringToUtf8),
-  )
-
-  def this(configuration: Configuration) = this(
-    configuration.ytConf(WriteSchemaHint),
-    configuration.ytConf(WriteTypeV3),
-    configuration.ytConf(StringToUtf8),
-  )
-
   private def ytLogicalTypeV3Variant(struct: StructType): YtLogicalType = {
     if (isVariantOverTuple(struct)) {
       YtLogicalType.VariantOverTuple {
@@ -134,4 +122,18 @@ class WriteSchemaConverter(
     TableSchema.fromYTree(ytLogicalSchemaImpl(sparkSchema, sortOption,
       isTableSchema = true))
   }
+}
+
+object WriteSchemaConverter {
+  def apply(options: Map[String, String]) = new WriteSchemaConverter(
+    options.ytConf(WriteSchemaHint),
+    options.ytConf(WriteTypeV3),
+    options.ytConf(StringToUtf8),
+  )
+
+  def apply(configuration: Configuration) = new WriteSchemaConverter(
+    configuration.ytConf(WriteSchemaHint),
+    configuration.ytConf(WriteTypeV3),
+    configuration.ytConf(StringToUtf8),
+  )
 }

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/WriteSchemaConverter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/WriteSchemaConverter.scala
@@ -12,7 +12,7 @@ import tech.ytsaurus.spyt.serializers.YtLogicalTypeSerializer.{serializeType, se
 import tech.ytsaurus.spyt.types.YTsaurusTypes
 import tech.ytsaurus.ysontree.{YTree, YTreeNode}
 
-case class WriteSchemaConverter(
+class WriteSchemaConverter(
   hint: Map[String, YtLogicalType] = Map.empty,
   typeV3Format: Boolean = false,
   stringToUtf8: Boolean = false,

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YsonRowConverter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YsonRowConverter.scala
@@ -174,7 +174,7 @@ class YsonRowConverter(schema: StructType, ytSchema: YtTypeHolder,
     }
   }
 
-  private val tableSchema = WriteSchemaConverter(Map.empty).tableSchema(schema, Unordered)
+  private val tableSchema = new WriteSchemaConverter().tableSchema(schema, Unordered)
 
   @tailrec
   final def writeRows(writer: TableWriter[Row], rows: Seq[Row]): Unit = {

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YsonRowConverter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YsonRowConverter.scala
@@ -174,7 +174,7 @@ class YsonRowConverter(schema: StructType, ytSchema: YtTypeHolder,
     }
   }
 
-  private val tableSchema = WriteSchemaConverter(Map.empty).tableSchema(schema, Unordered)
+  private val tableSchema = new WriteSchemaConverter(Map.empty).tableSchema(schema, Unordered)
 
   @tailrec
   final def writeRows(writer: TableWriter[Row], rows: Seq[Row]): Unit = {

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YsonRowConverter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YsonRowConverter.scala
@@ -174,7 +174,7 @@ class YsonRowConverter(schema: StructType, ytSchema: YtTypeHolder,
     }
   }
 
-  private val tableSchema = SchemaConverter.tableSchema(schema, Unordered, Map.empty)
+  private val tableSchema = WriteSchemaConverter(Map.empty).tableSchema(schema, Unordered)
 
   @tailrec
   final def writeRows(writer: TableWriter[Row], rows: Seq[Row]): Unit = {

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YsonRowConverter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YsonRowConverter.scala
@@ -174,7 +174,7 @@ class YsonRowConverter(schema: StructType, ytSchema: YtTypeHolder,
     }
   }
 
-  private val tableSchema = new WriteSchemaConverter(Map.empty).tableSchema(schema, Unordered)
+  private val tableSchema = WriteSchemaConverter(Map.empty).tableSchema(schema, Unordered)
 
   @tailrec
   final def writeRows(writer: TableWriter[Row], rows: Seq[Row]): Unit = {

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YtLogicalType.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YtLogicalType.scala
@@ -173,7 +173,7 @@ object YtLogicalType {
   case object Array extends CompositeYtLogicalTypeAlias(TypeName.List.getWireName)
 
   case class Struct(fields: Seq[(String, YtLogicalType, Metadata)]) extends CompositeYtLogicalType {
-    override def sparkType: DataType = StructType(fields
+    override def sparkType: StructType = StructType(fields
       .map { case (name, ytType, meta) => getStructField(name, ytType, meta) })
 
     import scala.collection.JavaConverters._

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/format/TestTableSettings.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/format/TestTableSettings.scala
@@ -11,7 +11,7 @@ case class TestTableSettings(schema: StructType,
                              sortOption: SortOption = Unordered,
                              writeSchemaHint: Map[String, YtLogicalType] = Map.empty,
                              otherOptions: Map[String, String] = Map.empty) extends YtTableSettings {
-  override def ytSchema: YTreeNode = new WriteSchemaConverter(Map.empty, typeV3Format = false).ytLogicalSchema(schema, sortOption)
+  override def ytSchema: YTreeNode = new WriteSchemaConverter().ytLogicalSchema(schema, sortOption)
 
   override def optionsAny: Map[String, Any] = otherOptions + ("dynamic" -> isDynamic)
 }

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/format/TestTableSettings.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/format/TestTableSettings.scala
@@ -2,9 +2,8 @@ package tech.ytsaurus.spyt.format
 
 import org.apache.spark.sql.types.StructType
 import tech.ytsaurus.spyt.serializers.SchemaConverter.{SortOption, Unordered}
-import tech.ytsaurus.spyt.serializers.SchemaConverter
+import tech.ytsaurus.spyt.serializers.{SchemaConverter, WriteSchemaConverter, YtLogicalType}
 import tech.ytsaurus.spyt.wrapper.table.YtTableSettings
-import tech.ytsaurus.spyt.serializers.{SchemaConverter, YtLogicalType}
 import tech.ytsaurus.ysontree.YTreeNode
 
 case class TestTableSettings(schema: StructType,
@@ -12,7 +11,7 @@ case class TestTableSettings(schema: StructType,
                              sortOption: SortOption = Unordered,
                              writeSchemaHint: Map[String, YtLogicalType] = Map.empty,
                              otherOptions: Map[String, String] = Map.empty) extends YtTableSettings {
-  override def ytSchema: YTreeNode = SchemaConverter.ytLogicalSchema(schema, sortOption, writeSchemaHint)
+  override def ytSchema: YTreeNode = WriteSchemaConverter(Map.empty, typeV3Format = false).ytLogicalSchema(schema, sortOption)
 
   override def optionsAny: Map[String, Any] = otherOptions + ("dynamic" -> isDynamic)
 }

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/format/TestTableSettings.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/format/TestTableSettings.scala
@@ -11,7 +11,7 @@ case class TestTableSettings(schema: StructType,
                              sortOption: SortOption = Unordered,
                              writeSchemaHint: Map[String, YtLogicalType] = Map.empty,
                              otherOptions: Map[String, String] = Map.empty) extends YtTableSettings {
-  override def ytSchema: YTreeNode = WriteSchemaConverter(Map.empty, typeV3Format = false).ytLogicalSchema(schema, sortOption)
+  override def ytSchema: YTreeNode = new WriteSchemaConverter(Map.empty, typeV3Format = false).ytLogicalSchema(schema, sortOption)
 
   override def optionsAny: Map[String, Any] = otherOptions + ("dynamic" -> isDynamic)
 }

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/format/YtDynamicTableWriterTest.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/format/YtDynamicTableWriterTest.scala
@@ -109,7 +109,7 @@ class YtDynamicTableWriterTest extends AnyFlatSpec with TmpDir with LocalSpark w
 
       if (createNewTable) {
         val tableSchema = if (externalTableSchema.isEmpty) {
-          schemaModifier(WriteSchemaConverter(Map.empty).tableSchema(df.schema, Unordered))
+          schemaModifier(new WriteSchemaConverter(Map.empty).tableSchema(df.schema, Unordered))
         } else {
           externalTableSchema.get
         }

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/format/YtDynamicTableWriterTest.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/format/YtDynamicTableWriterTest.scala
@@ -109,7 +109,7 @@ class YtDynamicTableWriterTest extends AnyFlatSpec with TmpDir with LocalSpark w
 
       if (createNewTable) {
         val tableSchema = if (externalTableSchema.isEmpty) {
-          schemaModifier(new WriteSchemaConverter(Map.empty).tableSchema(df.schema, Unordered))
+          schemaModifier(WriteSchemaConverter(Map.empty).tableSchema(df.schema, Unordered))
         } else {
           externalTableSchema.get
         }

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/format/YtDynamicTableWriterTest.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/format/YtDynamicTableWriterTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.matchers.should.Matchers
 import tech.ytsaurus.core.cypress.YPath
 import tech.ytsaurus.core.tables.{ColumnValueType, TableSchema}
 import tech.ytsaurus.spyt.exceptions._
-import tech.ytsaurus.spyt.serializers.{InternalRowSerializer, SchemaConverter}
+import tech.ytsaurus.spyt.serializers.{InternalRowSerializer, SchemaConverter, WriteSchemaConverter}
 import tech.ytsaurus.spyt.serializers.SchemaConverter.{Sorted, Unordered}
 import tech.ytsaurus.spyt.test.{LocalSpark, TmpDir}
 import tech.ytsaurus.spyt.wrapper.YtWrapper
@@ -109,7 +109,7 @@ class YtDynamicTableWriterTest extends AnyFlatSpec with TmpDir with LocalSpark w
 
       if (createNewTable) {
         val tableSchema = if (externalTableSchema.isEmpty) {
-          schemaModifier(SchemaConverter.tableSchema(df.schema, Unordered, Map.empty))
+          schemaModifier(WriteSchemaConverter(Map.empty).tableSchema(df.schema, Unordered))
         } else {
           externalTableSchema.get
         }

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/format/YtDynamicTableWriterTest.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/format/YtDynamicTableWriterTest.scala
@@ -109,7 +109,7 @@ class YtDynamicTableWriterTest extends AnyFlatSpec with TmpDir with LocalSpark w
 
       if (createNewTable) {
         val tableSchema = if (externalTableSchema.isEmpty) {
-          schemaModifier(WriteSchemaConverter(Map.empty).tableSchema(df.schema, Unordered))
+          schemaModifier(new WriteSchemaConverter().tableSchema(df.schema, Unordered))
         } else {
           externalTableSchema.get
         }

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/format/batch/ArrowBatchReaderTest.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/format/batch/ArrowBatchReaderTest.scala
@@ -26,7 +26,7 @@ class ArrowBatchReaderTest extends FlatSpec with TmpDir with SchemaTestUtils
 
   it should "read old arrow format (< 0.15.0)" in {
     val stream = new TestInputStream(getClass.getResourceAsStream("arrow_old"))
-    val reader = new ArrowBatchReader(stream, schema, WriteSchemaConverter().tableSchema(schema))
+    val reader = new ArrowBatchReader(stream, schema, new WriteSchemaConverter().tableSchema(schema))
     val expected = readExpected("arrow_old_expected", schema)
 
     val rows = readFully(reader, schema, Int.MaxValue)
@@ -35,7 +35,7 @@ class ArrowBatchReaderTest extends FlatSpec with TmpDir with SchemaTestUtils
 
   it should "read new arrow format (>= 0.15.0)" in {
     val stream = new TestInputStream(getClass.getResourceAsStream("arrow_new"))
-    val reader = new ArrowBatchReader(stream, schema, WriteSchemaConverter().tableSchema(schema))
+    val reader = new ArrowBatchReader(stream, schema, new WriteSchemaConverter().tableSchema(schema))
     val expected = readExpected("arrow_new_expected", schema)
 
     val rows = readFully(reader, schema, Int.MaxValue)
@@ -50,7 +50,7 @@ class ArrowBatchReaderTest extends FlatSpec with TmpDir with SchemaTestUtils
     df.write.optimizeFor(OptimizeMode.Scan).yt(tmpPath)
 
     val stream = YtWrapper.readTableArrowStream(YPath.simple(tmpPath))
-    val reader = new ArrowBatchReader(stream, schema, WriteSchemaConverter().tableSchema(schema))
+    val reader = new ArrowBatchReader(stream, schema, new WriteSchemaConverter().tableSchema(schema))
 
     val rows = readFully(reader, schema, Int.MaxValue)
     rows should contain theSameElementsAs data.map(Row(_))
@@ -76,7 +76,7 @@ class ArrowBatchReaderTest extends FlatSpec with TmpDir with SchemaTestUtils
 
     def testSlice(data: Seq[Int], batchSize: Int, lowerRowIndex: Int, upperRowIndex: Int): Unit = {
       val stream = YtWrapper.readTableArrowStream(YPath.simple(tmpPath).withRange(lowerRowIndex, upperRowIndex))
-      val reader = new ArrowBatchReader(stream, schema, WriteSchemaConverter().tableSchema(schema))
+      val reader = new ArrowBatchReader(stream, schema, new WriteSchemaConverter().tableSchema(schema))
 
       val rows = readFully(reader, schema, batchSize)
       val expected = data.slice(lowerRowIndex, upperRowIndex).map(Row(_))

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/format/batch/ArrowBatchReaderTest.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/format/batch/ArrowBatchReaderTest.scala
@@ -8,7 +8,7 @@ import tech.ytsaurus.spyt.wrapper.YtWrapper
 import tech.ytsaurus.spyt.wrapper.table.OptimizeMode
 import tech.ytsaurus.spyt.{SchemaTestUtils, YtReader, YtWriter}
 import tech.ytsaurus.core.cypress.YPath
-import tech.ytsaurus.spyt.serializers.SchemaConverter
+import tech.ytsaurus.spyt.serializers.{SchemaConverter, WriteSchemaConverter}
 import tech.ytsaurus.spyt.wrapper.table.YtArrowInputStream
 
 import java.io.InputStream
@@ -26,7 +26,7 @@ class ArrowBatchReaderTest extends FlatSpec with TmpDir with SchemaTestUtils
 
   it should "read old arrow format (< 0.15.0)" in {
     val stream = new TestInputStream(getClass.getResourceAsStream("arrow_old"))
-    val reader = new ArrowBatchReader(stream, schema, SchemaConverter.tableSchema(schema))
+    val reader = new ArrowBatchReader(stream, schema, WriteSchemaConverter().tableSchema(schema))
     val expected = readExpected("arrow_old_expected", schema)
 
     val rows = readFully(reader, schema, Int.MaxValue)
@@ -35,7 +35,7 @@ class ArrowBatchReaderTest extends FlatSpec with TmpDir with SchemaTestUtils
 
   it should "read new arrow format (>= 0.15.0)" in {
     val stream = new TestInputStream(getClass.getResourceAsStream("arrow_new"))
-    val reader = new ArrowBatchReader(stream, schema, SchemaConverter.tableSchema(schema))
+    val reader = new ArrowBatchReader(stream, schema, WriteSchemaConverter().tableSchema(schema))
     val expected = readExpected("arrow_new_expected", schema)
 
     val rows = readFully(reader, schema, Int.MaxValue)
@@ -50,7 +50,7 @@ class ArrowBatchReaderTest extends FlatSpec with TmpDir with SchemaTestUtils
     df.write.optimizeFor(OptimizeMode.Scan).yt(tmpPath)
 
     val stream = YtWrapper.readTableArrowStream(YPath.simple(tmpPath))
-    val reader = new ArrowBatchReader(stream, schema, SchemaConverter.tableSchema(schema))
+    val reader = new ArrowBatchReader(stream, schema, WriteSchemaConverter().tableSchema(schema))
 
     val rows = readFully(reader, schema, Int.MaxValue)
     rows should contain theSameElementsAs data.map(Row(_))
@@ -76,7 +76,7 @@ class ArrowBatchReaderTest extends FlatSpec with TmpDir with SchemaTestUtils
 
     def testSlice(data: Seq[Int], batchSize: Int, lowerRowIndex: Int, upperRowIndex: Int): Unit = {
       val stream = YtWrapper.readTableArrowStream(YPath.simple(tmpPath).withRange(lowerRowIndex, upperRowIndex))
-      val reader = new ArrowBatchReader(stream, schema, SchemaConverter.tableSchema(schema))
+      val reader = new ArrowBatchReader(stream, schema, WriteSchemaConverter().tableSchema(schema))
 
       val rows = readFully(reader, schema, batchSize)
       val expected = data.slice(lowerRowIndex, upperRowIndex).map(Row(_))

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/serializers/SchemaConverterTest.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/serializers/SchemaConverterTest.scala
@@ -240,10 +240,10 @@ class SchemaConverterTest extends AnyFlatSpec with Matchers
 
   it should "correctly write byte and short" in {
     withConf(SparkYtConfiguration.Schema.ForcingNullableIfNoMetadata, false){
-      val df_0 = spark.createDataFrame(
+      spark.createDataFrame(
         spark.sparkContext.parallelize(rightSparkDataForByteAndShortTests),
-        rightSparkSchemaForByteAndShortTests)
-      df_0.write
+        rightSparkSchemaForByteAndShortTests,
+      ).write
         .option(YtTableSparkSettings.WriteTypeV3.name, value = true)
         .option(YtTableSparkSettings.NullTypeAllowed.name, value = false)
         .option(YtUtils.Options.PARSING_TYPE_V3, value = true)
@@ -274,14 +274,13 @@ class SchemaConverterTest extends AnyFlatSpec with Matchers
 
   it should "write string by default" in {
     withConf(SparkYtConfiguration.Schema.ForcingNullableIfNoMetadata, false){
-      val df_0 = spark.createDataFrame(
+      spark.createDataFrame(
         spark.sparkContext.parallelize(Seq(Row("string", "binary".getBytes))),
         StructType(Seq(
           StructField("string", StringType, nullable = false),
           StructField("binary", BinaryType, nullable = false),
         ))
-      )
-      df_0.write.yt(tmpPath)
+      ).write.yt(tmpPath)
 
       val schema = TableSchema.fromYTree(YtWrapper.attribute(tmpPath, "schema"))
 

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/serializers/SchemaConverterTest.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/serializers/SchemaConverterTest.scala
@@ -145,7 +145,7 @@ class SchemaConverterTest extends AnyFlatSpec with Matchers
   }
 
   it should "convert spark schema to yt one with parsing type v3" in {
-    val res = TableSchema.fromYTree(WriteSchemaConverter(Map.empty, typeV3Format = true).ytLogicalSchema(sparkSchema, Unordered))
+    val res = TableSchema.fromYTree(new WriteSchemaConverter(Map.empty, typeV3Format = true).ytLogicalSchema(sparkSchema, Unordered))
     res shouldBe TableSchema.builder().setUniqueKeys(false)
       .addValue("Null", TiType.nullType())
       .addValue("Long", TiType.int64())
@@ -178,7 +178,7 @@ class SchemaConverterTest extends AnyFlatSpec with Matchers
         .key("required").value(false).buildMap
     }
 
-    val res = WriteSchemaConverter(Map.empty, typeV3Format = false).ytLogicalSchema(sparkSchema, Unordered)
+    val res = new WriteSchemaConverter(Map.empty, typeV3Format = false).ytLogicalSchema(sparkSchema, Unordered)
     res shouldBe YTree.builder
       .beginAttributes
       .key("strict").value(true)

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/serializers/SchemaConverterTest.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/serializers/SchemaConverterTest.scala
@@ -145,7 +145,7 @@ class SchemaConverterTest extends AnyFlatSpec with Matchers
   }
 
   it should "convert spark schema to yt one with parsing type v3" in {
-    val res = TableSchema.fromYTree(new WriteSchemaConverter(Map.empty, typeV3Format = true).ytLogicalSchema(sparkSchema, Unordered))
+    val res = TableSchema.fromYTree(new WriteSchemaConverter(typeV3Format = true).ytLogicalSchema(sparkSchema, Unordered))
     res shouldBe TableSchema.builder().setUniqueKeys(false)
       .addValue("Null", TiType.nullType())
       .addValue("Long", TiType.int64())
@@ -178,7 +178,7 @@ class SchemaConverterTest extends AnyFlatSpec with Matchers
         .key("required").value(false).buildMap
     }
 
-    val res = new WriteSchemaConverter(Map.empty, typeV3Format = false).ytLogicalSchema(sparkSchema, Unordered)
+    val res = new WriteSchemaConverter().ytLogicalSchema(sparkSchema, Unordered)
     res shouldBe YTree.builder
       .beginAttributes
       .key("strict").value(true)

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/streaming/YTsaurusStreamingTest.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/streaming/YTsaurusStreamingTest.scala
@@ -4,7 +4,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.streaming.Trigger.ProcessingTime
 import org.apache.spark.sql.{DataFrame, SaveMode}
 import org.scalatest.{FlatSpec, Matchers}
-import tech.ytsaurus.spyt.serializers.SchemaConverter
+import tech.ytsaurus.spyt.serializers.{SchemaConverter, WriteSchemaConverter}
 import tech.ytsaurus.spyt.test._
 import tech.ytsaurus.spyt.wrapper.YtWrapper
 
@@ -72,7 +72,7 @@ class YTsaurusStreamingTest extends FlatSpec with Matchers with LocalSpark with 
       .load()
       .select(floor(rand() * 10).as("num"))
 
-    prepareOrderedTestTable(path, SchemaConverter.tableSchema(numbers.schema), enableDynamicStoreRead = true)
+    prepareOrderedTestTable(path, WriteSchemaConverter().tableSchema(numbers.schema), enableDynamicStoreRead = true)
 
     val job = numbers
       .writeStream
@@ -152,7 +152,7 @@ class YTsaurusStreamingTest extends FlatSpec with Matchers with LocalSpark with 
       .option("consumer_path", consumerPath)
       .load(queuePath)
 
-    prepareOrderedTestTable(resultPath, SchemaConverter.tableSchema(numbers.schema), enableDynamicStoreRead = true)
+    prepareOrderedTestTable(resultPath, WriteSchemaConverter().tableSchema(numbers.schema), enableDynamicStoreRead = true)
 
     val job = numbers
       .writeStream

--- a/data-source/src/test/scala/tech/ytsaurus/spyt/streaming/YTsaurusStreamingTest.scala
+++ b/data-source/src/test/scala/tech/ytsaurus/spyt/streaming/YTsaurusStreamingTest.scala
@@ -72,7 +72,7 @@ class YTsaurusStreamingTest extends FlatSpec with Matchers with LocalSpark with 
       .load()
       .select(floor(rand() * 10).as("num"))
 
-    prepareOrderedTestTable(path, WriteSchemaConverter().tableSchema(numbers.schema), enableDynamicStoreRead = true)
+    prepareOrderedTestTable(path, new WriteSchemaConverter().tableSchema(numbers.schema), enableDynamicStoreRead = true)
 
     val job = numbers
       .writeStream
@@ -152,7 +152,7 @@ class YTsaurusStreamingTest extends FlatSpec with Matchers with LocalSpark with 
       .option("consumer_path", consumerPath)
       .load(queuePath)
 
-    prepareOrderedTestTable(resultPath, WriteSchemaConverter().tableSchema(numbers.schema), enableDynamicStoreRead = true)
+    prepareOrderedTestTable(resultPath, new WriteSchemaConverter().tableSchema(numbers.schema), enableDynamicStoreRead = true)
 
     val job = numbers
       .writeStream


### PR DESCRIPTION
`WriteSchemaConverter` was extracted from `SchemaConverter`.
A couple tests of the new feature were added to the `SchemaConverterTest`.