### PR TITLE
Write protocol should be Apache Arrow

### DIFF
--- a/data-source/src/main/scala/tech/ytsaurus/client/ArrowTableRowsSerializer.java
+++ b/data-source/src/main/scala/tech/ytsaurus/client/ArrowTableRowsSerializer.java
@@ -1,0 +1,1171 @@
+package tech.ytsaurus.client;
+
+import io.netty.buffer.ByteBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.*;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.ipc.WriteChannel;
+import org.apache.arrow.vector.ipc.message.IpcOption;
+import org.apache.arrow.vector.ipc.message.MessageSerializer;
+import org.apache.arrow.vector.types.DateUnit;
+import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import tech.ytsaurus.rpcproxy.ERowsetFormat;
+import tech.ytsaurus.rpcproxy.TRowsetDescriptor;
+import tech.ytsaurus.spyt.format.batch.ArrowUtils;
+import tech.ytsaurus.spyt.serialization.YsonDecoder;
+import tech.ytsaurus.typeinfo.DecimalType;
+import tech.ytsaurus.yson.YsonBinaryWriter;
+import tech.ytsaurus.ysontree.YTreeBuilder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.WritableByteChannel;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ArrowTableRowsSerializer<Struct, List, Dict, Getters extends YTGetters<Struct, List, Dict>> extends TableRowsSerializer<Struct> implements AutoCloseable {
+    private abstract class ArrowGetterFromStruct {
+        public final Field field;
+        public final ArrowType arrowType;
+
+        ArrowGetterFromStruct(Field field) {
+            super();
+            this.field = field;
+            this.arrowType = field.getType();
+        }
+
+        public final ArrowType getArrowType() {
+            return arrowType;
+        }
+
+        public abstract ArrowWriterFromStruct writer(ValueVector valueVector);
+    }
+
+    private abstract class ArrowWriterFromStruct {
+        abstract void setFromStruct(Struct struct);
+    }
+
+    private abstract class ArrowGetterFromList {
+        public final Field field;
+        public final ArrowType arrowType;
+
+        ArrowGetterFromList(Field field) {
+            this.field = field;
+            this.arrowType = field.getType();
+        }
+
+        public final ArrowType getArrowType() {
+            return arrowType;
+        }
+
+        public abstract ArrowWriterFromList writer(ValueVector valueVector);
+    }
+
+    private abstract class ArrowWriterFromList {
+        abstract void setFromList(List list, int i);
+    }
+
+    private ArrowGetterFromList arrowGetter(String name, Getters.FromList getter) {
+        var optionalGetter = getter instanceof YTGetters.FromListToOptional
+                ? (Getters.FromListToOptional) getter
+                : null;
+        var nonEmptyGetter = optionalGetter != null ? (Getters.FromList) optionalGetter.getNotEmptyGetter() : getter;
+        var arrowGetter = nonComplexArrowGetter(name, nonEmptyGetter);
+        if (arrowGetter != null) {
+            return optionalGetter == null ? arrowGetter : new ArrowGetterFromList(new Field(name, new FieldType(
+                    true, arrowGetter.field.getType(), null
+            ), arrowGetter.field.getChildren())) {
+                @Override
+                public ArrowWriterFromList writer(ValueVector valueVector) {
+                    var nonOptionalWriter = arrowGetter.writer(valueVector);
+                    return new ArrowWriterFromList() {
+                        @Override
+                        public void setFromList(List list, int i) {
+                            nonOptionalWriter.setFromList(optionalGetter.isEmpty(list, i) ? null : list, i);
+                        }
+                    };
+                }
+            };
+        }
+        return new ArrowGetterFromList(new Field(name, new FieldType(
+                optionalGetter != null, new ArrowType.Binary(), null
+        ), new ArrayList<>())) {
+            @Override
+            public ArrowWriterFromList writer(ValueVector valueVector) {
+                var varBinaryVector = (VarBinaryVector) valueVector;
+                return new ArrowWriterFromList() {
+                    @Override
+                    public void setFromList(List list, int i) {
+                        if (optionalGetter != null && optionalGetter.isEmpty(list, i)) {
+                            varBinaryVector.setNull(varBinaryVector.getValueCount());
+                        } else {
+                            var byteArrayOutputStream = new ByteArrayOutputStream();
+                            try (var ysonBinaryWriter = new YsonBinaryWriter(byteArrayOutputStream)) {
+                                nonEmptyGetter.getYson(list, i, ysonBinaryWriter);
+                            }
+                            varBinaryVector.set(varBinaryVector.getValueCount(), byteArrayOutputStream.toByteArray());
+                        }
+                        varBinaryVector.setValueCount(varBinaryVector.getValueCount() + 1);
+                    }
+                };
+            }
+        };
+    }
+
+    private ArrowGetterFromStruct arrowGetter(String name, Getters.FromStruct getter) {
+        var optionalGetter = getter instanceof YTGetters.FromStructToOptional
+                ? (Getters.FromStructToOptional) getter
+                : null;
+        var nonEmptyGetter = optionalGetter != null ? (Getters.FromStruct) optionalGetter.getNotEmptyGetter() : getter;
+        var arrowGetter = nonComplexArrowGetter(name, nonEmptyGetter);
+        if (arrowGetter != null) {
+            return optionalGetter == null ? arrowGetter : new ArrowGetterFromStruct(new Field(name, new FieldType(
+                    true, arrowGetter.field.getType(), null
+            ), arrowGetter.field.getChildren())) {
+                @Override
+                public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                    var nonOptionalWriter = arrowGetter.writer(valueVector);
+                    return new ArrowWriterFromStruct() {
+                        @Override
+                        public void setFromStruct(Struct struct) {
+                            nonOptionalWriter.setFromStruct(optionalGetter.isEmpty(struct) ? null : struct);
+                        }
+                    };
+                }
+            };
+        } else {
+            return new ArrowGetterFromStruct(new Field(name, new FieldType(
+                    optionalGetter != null, new ArrowType.Binary(), null
+            ), new ArrayList<>())) {
+                @Override
+                public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                    var varBinaryVector = (VarBinaryVector) valueVector;
+                    return new ArrowWriterFromStruct() {
+                        @Override
+                        void setFromStruct(Struct struct) {
+                            if (optionalGetter != null && optionalGetter.isEmpty(struct)) {
+                                varBinaryVector.setNull(varBinaryVector.getValueCount());
+                            } else {
+                                var byteArrayOutputStream = new ByteArrayOutputStream();
+                                try (var ysonBinaryWriter = new YsonBinaryWriter(byteArrayOutputStream)) {
+                                    nonEmptyGetter.getYson(struct, ysonBinaryWriter);
+                                }
+                                varBinaryVector.set(varBinaryVector.getValueCount(), byteArrayOutputStream.toByteArray());
+                            }
+                            varBinaryVector.setValueCount(varBinaryVector.getValueCount() + 1);
+                        }
+                    };
+                }
+            };
+        }
+    }
+
+    private Field field(String name, ArrowType arrowType) {
+        return new Field(name, new FieldType(false, arrowType, null), Collections.emptyList());
+    }
+
+    private ArrowGetterFromList nonComplexArrowGetter(String name, Getters.FromList getter) {
+        var tiType = getter.getTiType();
+        switch (tiType.getTypeName()) {
+            case String: {
+                var stringGetter = (Getters.FromListToString) getter;
+                return new ArrowGetterFromList(
+                        new Field(name, new FieldType(false, new ArrowType.Binary(), null), new ArrayList<>())
+                ) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var varBinaryVector = (VarBinaryVector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    varBinaryVector.setNull(varBinaryVector.getValueCount());
+                                } else {
+                                    var byteBuffer = stringGetter.getString(list, i);
+                                    varBinaryVector.set(
+                                            varBinaryVector.getValueCount(),
+                                            byteBuffer, byteBuffer.position(), byteBuffer.remaining()
+                                    );
+                                }
+                                varBinaryVector.setValueCount(varBinaryVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Int8: {
+                var byteGetter = (Getters.FromListToByte) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.Int(8, true))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var tinyIntVector = (TinyIntVector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    tinyIntVector.setNull(tinyIntVector.getValueCount());
+                                } else {
+                                    tinyIntVector.set(tinyIntVector.getValueCount(), byteGetter.getByte(list, i));
+                                }
+                                tinyIntVector.setValueCount(tinyIntVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Uint8: {
+                var byteGetter = (Getters.FromListToByte) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.Int(8, false))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var uInt1Vector = (UInt1Vector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    uInt1Vector.setNull(uInt1Vector.getValueCount());
+                                } else {
+                                    uInt1Vector.set(uInt1Vector.getValueCount(), byteGetter.getByte(list, i));
+                                }
+                                uInt1Vector.setValueCount(uInt1Vector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Int16: {
+                var shortGetter = (Getters.FromListToShort) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.Int(16, true))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var smallIntVector = (SmallIntVector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    smallIntVector.setNull(smallIntVector.getValueCount());
+                                } else {
+                                    smallIntVector.set(smallIntVector.getValueCount(), shortGetter.getShort(list, i));
+                                }
+                                smallIntVector.setValueCount(smallIntVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Uint16: {
+                var shortGetter = (Getters.FromListToShort) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.Int(16, false))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var uInt2Vector = (UInt2Vector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    uInt2Vector.setNull(uInt2Vector.getValueCount());
+                                } else {
+                                    uInt2Vector.set(uInt2Vector.getValueCount(), shortGetter.getShort(list, i));
+                                }
+                                uInt2Vector.setValueCount(uInt2Vector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Int32: {
+                var intGetter = (Getters.FromListToInt) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.Int(32, true))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var intVector = (IntVector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    intVector.setNull(intVector.getValueCount());
+                                } else {
+                                    intVector.set(intVector.getValueCount(), intGetter.getInt(list, i));
+                                }
+                                intVector.setValueCount(intVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Uint32: {
+                var intGetter = (Getters.FromListToInt) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.Int(32, false))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var uInt4Vector = (UInt4Vector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    uInt4Vector.setNull(uInt4Vector.getValueCount());
+                                } else {
+                                    uInt4Vector.set(uInt4Vector.getValueCount(), intGetter.getInt(list, i));
+                                }
+                                uInt4Vector.setValueCount(uInt4Vector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Interval:
+            case Interval64:
+            case Int64: {
+                var longGetter = (Getters.FromListToLong) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.Int(64, true))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var bigIntVector = (BigIntVector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    bigIntVector.setNull(bigIntVector.getValueCount());
+                                } else {
+                                    bigIntVector.set(bigIntVector.getValueCount(), longGetter.getLong(list, i));
+                                }
+                                bigIntVector.setValueCount(bigIntVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Uint64: {
+                var longGetter = (Getters.FromListToLong) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.Int(64, false))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var uInt8Vector = (UInt8Vector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    uInt8Vector.setNull(uInt8Vector.getValueCount());
+                                } else {
+                                    uInt8Vector.set(uInt8Vector.getValueCount(), longGetter.getLong(list, i));
+                                }
+                                uInt8Vector.setValueCount(uInt8Vector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Bool: {
+                var booleanGetter = (Getters.FromListToBoolean) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.Bool())) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var bitVector = (BitVector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    bitVector.setNull(bitVector.getValueCount());
+                                } else {
+                                    bitVector.set(bitVector.getValueCount(), booleanGetter.getBoolean(list, i) ? 1 : 0);
+                                }
+                                bitVector.setValueCount(bitVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Float: {
+                var floatGetter = (Getters.FromListToFloat) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var float4Vector = (Float4Vector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    float4Vector.setNull(float4Vector.getValueCount());
+                                } else {
+                                    float4Vector.set(float4Vector.getValueCount(), floatGetter.getFloat(list, i));
+                                }
+                                float4Vector.setValueCount(float4Vector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Double: {
+                var doubleGetter = (Getters.FromListToDouble) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var float8Vector = (Float8Vector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    float8Vector.setNull(float8Vector.getValueCount());
+                                } else {
+                                    float8Vector.set(float8Vector.getValueCount(), doubleGetter.getDouble(list, i));
+                                }
+                                float8Vector.setValueCount(float8Vector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Decimal: {
+                var decimalGetter = (Getters.FromListToBigDecimal) getter;
+                var decimalType = (DecimalType) decimalGetter.getTiType();
+                return new ArrowGetterFromList(field(name, new ArrowType.Decimal(
+                        decimalType.getPrecision(), decimalType.getScale()
+                ))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var decimalVector = (DecimalVector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    decimalVector.setNull(decimalVector.getValueCount());
+                                } else {
+                                    decimalVector.set(decimalVector.getValueCount(), decimalGetter.getBigDecimal(list, i));
+                                }
+                                decimalVector.setValueCount(decimalVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Date:
+            case Date32: {
+                var intGetter = (Getters.FromListToInt) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.Date(DateUnit.DAY))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var dateDayVector = (DateDayVector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    dateDayVector.setNull(dateDayVector.getValueCount());
+                                } else {
+                                    dateDayVector.set(dateDayVector.getValueCount(), intGetter.getInt(list, i));
+                                }
+                                dateDayVector.setValueCount(dateDayVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Datetime:
+            case Datetime64: {
+                var longGetter = (Getters.FromListToLong) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.Date(DateUnit.MILLISECOND))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var dateMilliVector = (DateMilliVector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    dateMilliVector.setNull(dateMilliVector.getValueCount());
+                                } else {
+                                    dateMilliVector.set(dateMilliVector.getValueCount(), longGetter.getLong(list, i));
+                                }
+                                dateMilliVector.setValueCount(dateMilliVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Timestamp:
+            case Timestamp64: {
+                var longGetter = (Getters.FromListToLong) getter;
+                return new ArrowGetterFromList(field(name, new ArrowType.Timestamp(TimeUnit.MICROSECOND, null))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var timeStampMicroVector = (TimeStampMicroVector) valueVector;
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    timeStampMicroVector.setNull(timeStampMicroVector.getValueCount());
+                                } else {
+                                    timeStampMicroVector.set(timeStampMicroVector.getValueCount(), longGetter.getLong(list, i));
+                                }
+                                timeStampMicroVector.setValueCount(timeStampMicroVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case List: {
+                var listGetter = (Getters.FromListToList) getter;
+                var elementGetter = listGetter.getElementGetter();
+                var itemGetter = arrowGetter("item", (Getters.FromList) elementGetter);
+                return new ArrowGetterFromList(new Field(name, new FieldType(
+                        false, new ArrowType.List(), null
+                ), Collections.singletonList(itemGetter.field))) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var listVector = (ListVector) valueVector;
+                        var dataWriter = itemGetter.writer(listVector.getDataVector());
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                var value = list == null ? null : (List) listGetter.getList(list, i);
+                                if (value != null) {
+                                    int size = elementGetter.getSize(value);
+                                    listVector.startNewValue(listVector.getValueCount());
+                                    for (int j = 0; j < size; j++) {
+                                        dataWriter.setFromList(value, j);
+                                    }
+                                    listVector.endValue(listVector.getValueCount(), size);
+                                }
+                                listVector.setValueCount(listVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Dict: {
+                var dictGetter = (Getters.FromListToDict) getter;
+                var fromDictGetter = dictGetter.getGetter();
+                var keyGetter = nonComplexArrowGetter("key", (Getters.FromList) fromDictGetter.getKeyGetter());
+                var valueGetter = arrowGetter("value", (Getters.FromList) fromDictGetter.getValueGetter());
+                if (keyGetter == null || valueGetter == null) {
+                    return null;
+                }
+                return new ArrowGetterFromList(new Field(
+                        name, new FieldType(false, new ArrowType.Map(false), null),
+                        Collections.singletonList(new Field(
+                                "entries", new FieldType(false, new ArrowType.Struct(), null),
+                                Arrays.asList(keyGetter.field, valueGetter.field)
+                        ))
+                )) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var mapVector = (MapVector) valueVector;
+                        var structVector = (StructVector) mapVector.getDataVector();
+                        var keyWriter = keyGetter.writer(structVector.getChildByOrdinal(0));
+                        var valueWriter = valueGetter.writer(structVector.getChildByOrdinal(1));
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                var dict = list == null ? null : dictGetter.getDict(list, i);
+                                if (dict != null) {
+                                    int size = fromDictGetter.getSize(dict);
+                                    var keys = fromDictGetter.getKeys(dict);
+                                    var values = fromDictGetter.getValues(dict);
+                                    mapVector.startNewValue(mapVector.getValueCount());
+                                    for (int j = 0; j < size; j++) {
+                                        structVector.setIndexDefined(structVector.getValueCount());
+                                        keyWriter.setFromList((List) keys, j);
+                                        valueWriter.setFromList((List) values, j);
+                                        structVector.setValueCount(structVector.getValueCount() + 1);
+                                    }
+                                    mapVector.endValue(mapVector.getValueCount(), size);
+                                }
+                                mapVector.setValueCount(mapVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Struct: {
+                var structGetter = (Getters.FromListToStruct) getter;
+                var members = (java.util.List<Map.Entry<String, Getters.FromStruct>>) structGetter.getMembersGetters();
+                var membersGetters = new ArrayList<ArrowGetterFromStruct>(members.size());
+                for (Map.Entry<String, Getters.FromStruct> member : members) {
+                    membersGetters.add(arrowGetter(member.getKey(), member.getValue()));
+                }
+                return new ArrowGetterFromList(new Field(
+                        name, new FieldType(false, new ArrowType.Struct(), null),
+                        membersGetters.stream().map(member -> member.field).collect(Collectors.toList())
+                )) {
+                    @Override
+                    public ArrowWriterFromList writer(ValueVector valueVector) {
+                        var structVector = (StructVector) valueVector;
+                        var membersWriters = new ArrayList<ArrowWriterFromStruct>(members.size());
+                        for (int i = 0; i < members.size(); i++) {
+                            membersWriters.add(membersGetters.get(i).writer(structVector.getChildByOrdinal(i)));
+                        }
+                        return new ArrowWriterFromList() {
+                            @Override
+                            void setFromList(List list, int i) {
+                                if (list == null) {
+                                    for (int j = 0; j < members.size(); j++) {
+                                        membersWriters.get(j).setFromStruct(null);
+                                    }
+                                } else {
+                                    var struct = (Struct) structGetter.getStruct(list, i);
+                                    structVector.setIndexDefined(structVector.getValueCount());
+                                    for (int j = 0; j < members.size(); j++) {
+                                        membersWriters.get(j).setFromStruct(struct);
+                                    }
+                                }
+                                structVector.setValueCount(structVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            default:
+                return null;
+        }
+    }
+
+    private ArrowGetterFromStruct nonComplexArrowGetter(String name, Getters.FromStruct getter) {
+        var tiType = getter.getTiType();
+        switch (tiType.getTypeName()) {
+            case String: {
+                var stringGetter = (Getters.FromStructToString) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Binary())) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var varBinaryVector = (VarBinaryVector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    varBinaryVector.setNull(varBinaryVector.getValueCount());
+                                } else {
+                                    var byteBuffer = stringGetter.getString(struct);
+                                    varBinaryVector.set(
+                                            varBinaryVector.getValueCount(),
+                                            byteBuffer, byteBuffer.position(), byteBuffer.remaining()
+                                    );
+                                }
+                                varBinaryVector.setValueCount(varBinaryVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Int8: {
+                var byteGetter = (Getters.FromStructToByte) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Int(8, true))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var tinyIntVector = (TinyIntVector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    tinyIntVector.setNull(tinyIntVector.getValueCount());
+                                } else {
+                                    tinyIntVector.set(tinyIntVector.getValueCount(), byteGetter.getByte(struct));
+                                }
+                                tinyIntVector.setValueCount(tinyIntVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Uint8: {
+                var byteGetter = (Getters.FromStructToByte) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Int(8, false))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var uInt1Vector = (UInt1Vector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    uInt1Vector.setNull(uInt1Vector.getValueCount());
+                                } else {
+                                    uInt1Vector.set(uInt1Vector.getValueCount(), byteGetter.getByte(struct));
+                                }
+                                uInt1Vector.setValueCount(uInt1Vector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Int16: {
+                var shortGetter = (Getters.FromStructToShort) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Int(16, true))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var smallIntVector = (SmallIntVector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    smallIntVector.setNull(smallIntVector.getValueCount());
+                                } else {
+                                    smallIntVector.set(smallIntVector.getValueCount(), shortGetter.getShort(struct));
+                                }
+                                smallIntVector.setValueCount(smallIntVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Uint16: {
+                var shortGetter = (Getters.FromStructToShort) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Int(16, false))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var uInt2Vector = (UInt2Vector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    uInt2Vector.setNull(uInt2Vector.getValueCount());
+                                } else {
+                                    uInt2Vector.set(uInt2Vector.getValueCount(), shortGetter.getShort(struct));
+                                }
+                                uInt2Vector.setValueCount(uInt2Vector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Int32: {
+                var intGetter = (Getters.FromStructToInt) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Int(32, true))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var intVector = (IntVector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    intVector.setNull(intVector.getValueCount());
+                                } else {
+                                    intVector.set(intVector.getValueCount(), intGetter.getInt(struct));
+                                }
+                                intVector.setValueCount(intVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Uint32: {
+                var intGetter = (Getters.FromStructToInt) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Int(32, false))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var uInt4Vector = (UInt4Vector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    uInt4Vector.setNull(uInt4Vector.getValueCount());
+                                } else {
+                                    uInt4Vector.set(uInt4Vector.getValueCount(), intGetter.getInt(struct));
+                                }
+                                uInt4Vector.setValueCount(uInt4Vector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Interval:
+            case Interval64:
+            case Int64: {
+                var longGetter = (Getters.FromStructToLong) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Int(64, true))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var bigIntVector = (BigIntVector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    bigIntVector.setNull(bigIntVector.getValueCount());
+                                } else {
+                                    bigIntVector.set(bigIntVector.getValueCount(), longGetter.getLong(struct));
+                                }
+                                bigIntVector.setValueCount(bigIntVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Uint64: {
+                var longGetter = (Getters.FromStructToLong) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Int(64, false))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var uInt8Vector = (UInt8Vector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    uInt8Vector.setNull(uInt8Vector.getValueCount());
+                                } else {
+                                    uInt8Vector.set(uInt8Vector.getValueCount(), longGetter.getLong(struct));
+                                }
+                                uInt8Vector.setValueCount(uInt8Vector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Bool: {
+                var booleanGetter = (Getters.FromStructToBoolean) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Bool())) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var bitVector = (BitVector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    bitVector.setNull(bitVector.getValueCount());
+                                } else {
+                                    bitVector.set(bitVector.getValueCount(), booleanGetter.getBoolean(struct) ? 1 : 0);
+                                }
+                                bitVector.setValueCount(bitVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Float: {
+                var floatGetter = (Getters.FromStructToFloat) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var float4Vector = (Float4Vector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    float4Vector.setNull(float4Vector.getValueCount());
+                                } else {
+                                    float4Vector.set(float4Vector.getValueCount(), floatGetter.getFloat(struct));
+                                }
+                                float4Vector.setValueCount(float4Vector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Double: {
+                var doubleGetter = (Getters.FromStructToDouble) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var float8Vector = (Float8Vector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    float8Vector.setNull(float8Vector.getValueCount());
+                                } else {
+                                    float8Vector.set(float8Vector.getValueCount(), doubleGetter.getDouble(struct));
+                                }
+                                float8Vector.setValueCount(float8Vector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Decimal: {
+                var decimalGetter = (Getters.FromStructToBigDecimal) getter;
+                var decimalType = (DecimalType) decimalGetter.getTiType();
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Decimal(
+                        decimalType.getPrecision(), decimalType.getScale()
+                ))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var decimalVector = (DecimalVector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    decimalVector.setNull(decimalVector.getValueCount());
+                                } else {
+                                    decimalVector.set(decimalVector.getValueCount(), decimalGetter.getBigDecimal(struct));
+                                }
+                                decimalVector.setValueCount(decimalVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Date:
+            case Date32: {
+                var intGetter = (Getters.FromStructToInt) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Date(DateUnit.DAY))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var dateDayVector = (DateDayVector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    dateDayVector.setNull(dateDayVector.getValueCount());
+                                } else {
+                                    dateDayVector.set(dateDayVector.getValueCount(), intGetter.getInt(struct));
+                                }
+                                dateDayVector.setValueCount(dateDayVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Datetime:
+            case Datetime64: {
+                var longGetter = (Getters.FromStructToLong) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Date(DateUnit.MILLISECOND))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var dateMilliVector = (DateMilliVector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    dateMilliVector.setNull(dateMilliVector.getValueCount());
+                                } else {
+                                    dateMilliVector.set(dateMilliVector.getValueCount(), longGetter.getLong(struct));
+                                }
+                                dateMilliVector.setValueCount(dateMilliVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Timestamp:
+            case Timestamp64: {
+                var longGetter = (Getters.FromStructToLong) getter;
+                return new ArrowGetterFromStruct(field(name, new ArrowType.Timestamp(TimeUnit.MICROSECOND, null))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var timeStampMicroVector = (TimeStampMicroVector) valueVector;
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct struct) {
+                                if (struct == null) {
+                                    timeStampMicroVector.setNull(timeStampMicroVector.getValueCount());
+                                } else {
+                                    timeStampMicroVector.set(timeStampMicroVector.getValueCount(), longGetter.getLong(struct));
+                                }
+                                timeStampMicroVector.setValueCount(timeStampMicroVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case List: {
+                var listGetter = (Getters.FromStructToList) getter;
+                var elementGetter = (Getters.FromList) listGetter.getElementGetter();
+                var itemGetter = arrowGetter("item", elementGetter);
+                return new ArrowGetterFromStruct(new Field(name, new FieldType(
+                        false, new ArrowType.List(), null
+                ), Collections.singletonList(itemGetter.field))) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var listVector = (ListVector) valueVector;
+                        var dataWriter = itemGetter.writer(listVector.getDataVector());
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            public void setFromStruct(Struct struct) {
+                                var list = struct == null ? null : (List) listGetter.getList(struct);
+                                if (list != null) {
+                                    int size = elementGetter.getSize(list);
+                                    listVector.startNewValue(listVector.getValueCount());
+                                    for (int i = 0; i < size; i++) {
+                                        dataWriter.setFromList(list, i);
+                                    }
+                                    listVector.endValue(listVector.getValueCount(), size);
+                                }
+                                listVector.setValueCount(listVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Dict: {
+                var dictGetter = (Getters.FromStructToDict) getter;
+                var fromDictGetter = (Getters.FromDict) dictGetter.getGetter();
+                var keyGetter = nonComplexArrowGetter("key", (Getters.FromList) fromDictGetter.getKeyGetter());
+                var valueGetter = arrowGetter("value", (Getters.FromList) fromDictGetter.getValueGetter());
+                if (keyGetter == null || valueGetter == null) {
+                    return null;
+                }
+                return new ArrowGetterFromStruct(new Field(
+                        name, new FieldType(false, new ArrowType.Map(false), null),
+                        Collections.singletonList(new Field(
+                                "entries", new FieldType(false, new ArrowType.Struct(), null),
+                                Arrays.asList(keyGetter.field, valueGetter.field)
+                        ))
+                )) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var mapVector = (MapVector) valueVector;
+                        var structVector = (StructVector) mapVector.getDataVector();
+                        var keyWriter = keyGetter.writer(structVector.getChildByOrdinal(0));
+                        var valueWriter = valueGetter.writer(structVector.getChildByOrdinal(1));
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            public void setFromStruct(Struct struct) {
+                                var dict = struct == null ? null : dictGetter.getDict(struct);
+                                if (dict != null) {
+                                    int size = fromDictGetter.getSize(dict);
+                                    var keys = (List) fromDictGetter.getKeys(dict);
+                                    var values = (List) fromDictGetter.getValues(dict);
+                                    mapVector.startNewValue(mapVector.getValueCount());
+                                    for (int i = 0; i < size; i++) {
+                                        structVector.setIndexDefined(structVector.getValueCount());
+                                        keyWriter.setFromList(keys, i);
+                                        valueWriter.setFromList(values, i);
+                                        structVector.setValueCount(structVector.getValueCount() + 1);
+                                    }
+                                    mapVector.endValue(mapVector.getValueCount(), size);
+                                }
+                                mapVector.setValueCount(mapVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            case Struct: {
+                var structGetter = (Getters.FromStructToStruct) getter;
+                var members = (java.util.List<Map.Entry<String, Getters.FromStruct>>) structGetter.getMembersGetters();
+                var membersGetters = new ArrayList<ArrowGetterFromStruct>(members.size());
+                for (Map.Entry<String, ? extends Getters.FromStruct> member : members) {
+                    membersGetters.add(arrowGetter(member.getKey(), member.getValue()));
+                }
+                return new ArrowGetterFromStruct(new Field(
+                        name, new FieldType(false, new ArrowType.Struct(), null),
+                        membersGetters.stream().map(member -> member.field).collect(Collectors.toList())
+                )) {
+                    @Override
+                    public ArrowWriterFromStruct writer(ValueVector valueVector) {
+                        var structVector = (StructVector) valueVector;
+                        var membersWriters = new ArrayList<ArrowWriterFromStruct>(members.size());
+                        for (int i = 0; i < members.size(); i++) {
+                            membersWriters.add(membersGetters.get(i).writer(structVector.getChildByOrdinal(i)));
+                        }
+                        return new ArrowWriterFromStruct() {
+                            @Override
+                            void setFromStruct(Struct row) {
+                                if (row == null) {
+                                    for (int i = 0; i < members.size(); i++) {
+                                        membersWriters.get(i).setFromStruct(null);
+                                    }
+                                } else {
+                                    var struct = (Struct) structGetter.getStruct(row);
+                                    structVector.setIndexDefined(structVector.getValueCount());
+                                    for (int i = 0; i < members.size(); i++) {
+                                        membersWriters.get(i).setFromStruct(struct);
+                                    }
+                                }
+                                structVector.setValueCount(structVector.getValueCount() + 1);
+                            }
+                        };
+                    }
+                };
+            }
+            default:
+                return null;
+        }
+    }
+
+    private final java.util.List<ArrowGetterFromStruct> fieldGetters;
+    private final Schema schema;
+    private final BufferAllocator allocator =
+            ArrowUtils.rootAllocator().newChildAllocator("toBatchIterator", 0, Long.MAX_VALUE);
+
+    public ArrowTableRowsSerializer(java.util.List<? extends Map.Entry<String, ? extends Getters.FromStruct>> structsGetter) {
+        super(ERowsetFormat.RF_FORMAT);
+        fieldGetters = structsGetter.stream().map(memberGetter -> arrowGetter(
+                memberGetter.getKey(), memberGetter.getValue()
+        )).collect(Collectors.toList());
+        schema = new Schema(() -> fieldGetters.stream().map(getter -> getter.field).iterator());
+    }
+
+    @Override
+    public void close() {
+        allocator.close();
+    }
+
+    private static class ByteBufWritableByteChannel implements WritableByteChannel {
+        private final ByteBuf buf;
+
+        private ByteBufWritableByteChannel(ByteBuf buf) {
+            this.buf = buf;
+        }
+
+        @Override
+        public int write(ByteBuffer src) {
+            int remaining = src.remaining();
+            buf.writeBytes(src);
+            return remaining - src.remaining();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return buf.isWritable();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+
+    @Override
+    protected void writeMeta(ByteBuf buf, ByteBuf serializedRows, int rowsCount) {
+        try {
+            var writeChannel = new WriteChannel(new ByteBufWritableByteChannel(buf));
+            MessageSerializer.serialize(writeChannel, schema);
+            writeChannel.write(serializedRows.nioBuffer());
+            ArrowStreamWriter.writeEndOfStream(writeChannel, new IpcOption());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected void writeRowsWithoutCount(
+            ByteBuf buf, TRowsetDescriptor descriptor, java.util.List<Struct> rows, int[] idMapping
+    ) {
+        writeRows(buf, descriptor, rows, idMapping);
+    }
+
+    @Override
+    protected void writeRows(ByteBuf buf, TRowsetDescriptor descriptor, java.util.List<Struct> rows, int[] idMapping) {
+        try {
+            var writeChannel = new WriteChannel(new ByteBufWritableByteChannel(buf));
+            MessageSerializer.serialize(writeChannel, schema);
+            var root = VectorSchemaRoot.create(schema, allocator);
+            var unloader = new VectorUnloader(root);
+            var writers = IntStream.range(0, fieldGetters.size()).mapToObj(column -> {
+                var valueVector = root.getFieldVectors().get(column);
+                if (valueVector instanceof FixedWidthVector) {
+                    ((FixedWidthVector) valueVector).allocateNew(rows.size());
+                } else {
+                    valueVector.allocateNew();
+                }
+                return fieldGetters.get(column).writer(valueVector);
+            }).collect(Collectors.toList());
+            for (var row : rows) {
+                for (var writer : writers) {
+                    writer.setFromStruct(row);
+                }
+            }
+            root.setRowCount(rows.size());
+            try (var batch = unloader.getRecordBatch()) {
+                MessageSerializer.serialize(writeChannel, batch);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/data-source/src/main/scala/tech/ytsaurus/client/ArrowWriteSerializationContext.java
+++ b/data-source/src/main/scala/tech/ytsaurus/client/ArrowWriteSerializationContext.java
@@ -1,0 +1,24 @@
+package tech.ytsaurus.client;
+
+import tech.ytsaurus.client.request.Format;
+import tech.ytsaurus.client.request.SerializationContext;
+import tech.ytsaurus.rpcproxy.ERowsetFormat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ArrowWriteSerializationContext<T, L, D, G extends YTGetters<T, L, D>> extends SerializationContext<T> {
+    private final java.util.List<? extends Map.Entry<String, ? extends G.FromStruct>> rowGetters;
+
+    public ArrowWriteSerializationContext(
+            java.util.List<? extends Map.Entry<String, ? extends G.FromStruct>> rowGetters
+    ) {
+        this.rowsetFormat = ERowsetFormat.RF_FORMAT;
+        this.format = new Format("arrow", new HashMap<>());
+        this.rowGetters = rowGetters;
+    }
+
+    public java.util.List<? extends Map.Entry<String, ? extends G.FromStruct>> getRowGetters() {
+        return rowGetters;
+    }
+}

--- a/data-source/src/main/scala/tech/ytsaurus/client/InternalRowYTGetters.java
+++ b/data-source/src/main/scala/tech/ytsaurus/client/InternalRowYTGetters.java
@@ -1,0 +1,8 @@
+package tech.ytsaurus.client;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayData;
+import org.apache.spark.sql.catalyst.util.MapData;
+
+public class InternalRowYTGetters extends YTGetters<InternalRow, ArrayData, MapData> {
+}

--- a/data-source/src/main/scala/tech/ytsaurus/client/TableWriterBaseImpl.java
+++ b/data-source/src/main/scala/tech/ytsaurus/client/TableWriterBaseImpl.java
@@ -1,0 +1,114 @@
+package tech.ytsaurus.client;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
+
+import tech.ytsaurus.client.request.WriteTable;
+import tech.ytsaurus.client.rows.UnversionedRow;
+import tech.ytsaurus.client.rows.UnversionedRowSerializer;
+import tech.ytsaurus.client.rpc.Compression;
+import tech.ytsaurus.client.rpc.RpcUtil;
+import tech.ytsaurus.core.tables.TableSchema;
+import tech.ytsaurus.lang.NonNullApi;
+import tech.ytsaurus.rpcproxy.TWriteTableMeta;
+
+
+@NonNullApi
+class TableWriterBaseImpl<T> extends RawTableWriterImpl {
+    protected @Nullable
+    TableSchema schema;
+    protected final WriteTable<T> req;
+    protected @Nullable
+    TableRowsSerializer<T> tableRowsSerializer;
+    private final SerializationResolver serializationResolver;
+    @Nullable
+    protected ApiServiceTransaction transaction;
+
+    TableWriterBaseImpl(WriteTable<T> req, SerializationResolver serializationResolver) {
+        super(req.getWindowSize(), req.getPacketSize());
+        this.req = req;
+        this.serializationResolver = serializationResolver;
+        var format = this.req.getSerializationContext().getFormat();
+        if (format.isEmpty() || !"arrow".equals(format.get().getType())) {
+            tableRowsSerializer = TableRowsSerializer.createTableRowsSerializer(
+                    this.req.getSerializationContext(), serializationResolver
+            ).orElse(null);
+        }
+    }
+
+    public void setTransaction(ApiServiceTransaction transaction) {
+        if (this.transaction != null) {
+            throw new IllegalStateException("Write transaction already started");
+        }
+        this.transaction = transaction;
+    }
+
+    public CompletableFuture<TableWriterBaseImpl<T>> startUploadImpl() {
+        TableWriterBaseImpl<T> self = this;
+
+        return startUpload.thenApply((attachments) -> {
+            if (attachments.size() != 1) {
+                throw new IllegalArgumentException("protocol error");
+            }
+            byte[] head = attachments.get(0);
+            if (head == null) {
+                throw new IllegalArgumentException("protocol error");
+            }
+
+            TWriteTableMeta metadata = RpcUtil.parseMessageBodyWithCompression(
+                    head,
+                    TWriteTableMeta.parser(),
+                    Compression.None
+            );
+            self.schema = ApiServiceUtil.deserializeTableSchema(metadata.getSchema());
+            logger.debug("schema -> {}", schema.toYTree().toString());
+
+            {
+                var format = this.req.getSerializationContext().getFormat();
+                if (format.isPresent() && "arrow".equals(format.get().getType())) {
+                    tableRowsSerializer = new ArrowTableRowsSerializer<>(
+                            ((ArrowWriteSerializationContext<T, ?, ?, ?>) this.req.getSerializationContext()).getRowGetters()
+                    );
+                }
+            }
+
+            if (this.tableRowsSerializer == null) {
+                if (this.req.getSerializationContext().getObjectClass().isEmpty()) {
+                    throw new IllegalStateException("No object clazz");
+                }
+                Class<T> objectClazz = self.req.getSerializationContext().getObjectClass().get();
+                if (UnversionedRow.class.equals(objectClazz)) {
+                    this.tableRowsSerializer =
+                            (TableRowsSerializer<T>) new TableRowsWireSerializer<>(new UnversionedRowSerializer());
+                } else {
+                    this.tableRowsSerializer = new TableRowsWireSerializer<>(
+                            serializationResolver.createWireRowSerializer(
+                                    serializationResolver.forClass(objectClazz, self.schema))
+                    );
+                }
+            }
+
+            return self;
+        });
+    }
+
+    public boolean write(List<T> rows, TableSchema schema) throws IOException {
+        byte[] serializedRows = tableRowsSerializer.serializeRows(rows, schema);
+        return write(serializedRows);
+    }
+
+    @Override
+    public CompletableFuture<?> close() {
+        return super.close()
+                .thenCompose(response -> {
+                    if (transaction != null && transaction.isActive()) {
+                        return transaction.commit()
+                                .thenApply(unused -> response);
+                    }
+                    return CompletableFuture.completedFuture(response);
+                });
+    }
+}

--- a/data-source/src/main/scala/tech/ytsaurus/client/YTGetters.java
+++ b/data-source/src/main/scala/tech/ytsaurus/client/YTGetters.java
@@ -1,0 +1,177 @@
+package tech.ytsaurus.client;
+
+import tech.ytsaurus.typeinfo.*;
+import tech.ytsaurus.yson.YsonConsumer;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.Map;
+
+public class YTGetters<Struct, List, Dict> {
+    public abstract class Getter {
+        private Getter() {
+        }
+
+        public abstract TiType getTiType();
+    }
+
+    public abstract class FromStruct extends Getter {
+        private FromStruct() {
+        }
+
+        public abstract void getYson(Struct struct, YsonConsumer ysonConsumer);
+    }
+
+    public abstract class FromList extends Getter {
+        private FromList() {
+        }
+
+        public abstract int getSize(List list);
+
+        public abstract void getYson(List list, int i, YsonConsumer ysonConsumer);
+    }
+
+    public abstract class FromStructToYson extends FromStruct {
+    }
+
+    public abstract class FromListToYson extends FromList {
+    }
+
+    public abstract class FromDict extends Getter {
+        public abstract FromList getKeyGetter();
+
+        public abstract FromList getValueGetter();
+
+        public abstract int getSize(Dict dict);
+
+        public abstract List getKeys(Dict dict);
+
+        public abstract List getValues(Dict dict);
+    }
+
+    public abstract class FromStructToNull extends FromStruct {
+    }
+
+    public abstract class FromListToNull extends FromList {
+    }
+
+    public abstract class FromStructToOptional extends FromStruct {
+        public abstract FromStruct getNotEmptyGetter();
+
+        public abstract boolean isEmpty(Struct struct);
+    }
+
+    public abstract class FromListToOptional extends FromList {
+        public abstract FromList getNotEmptyGetter();
+
+        public abstract boolean isEmpty(List list, int i);
+    }
+
+    public abstract class FromStructToString extends FromStruct {
+        public abstract ByteBuffer getString(Struct struct);
+    }
+
+    public abstract class FromListToString extends FromList {
+        public abstract ByteBuffer getString(List struct, int i);
+    }
+
+    public abstract class FromStructToByte extends FromStruct {
+        public abstract byte getByte(Struct struct);
+    }
+
+    public abstract class FromListToByte extends FromList {
+        public abstract byte getByte(List list, int i);
+    }
+
+    public abstract class FromStructToShort extends FromStruct {
+        public abstract short getShort(Struct struct);
+    }
+
+    public abstract class FromListToShort extends FromList {
+        public abstract short getShort(List list, int i);
+    }
+
+    public abstract class FromStructToInt extends FromStruct {
+        public abstract int getInt(Struct struct);
+    }
+
+    public abstract class FromListToInt extends FromList {
+        public abstract int getInt(List list, int i);
+    }
+
+    public abstract class FromStructToLong extends FromStruct {
+        public abstract long getLong(Struct struct);
+    }
+
+    public abstract class FromListToLong extends FromList {
+        public abstract long getLong(List list, int i);
+    }
+
+    public abstract class FromStructToBoolean extends FromStruct {
+        public abstract boolean getBoolean(Struct struct);
+    }
+
+    public abstract class FromListToBoolean extends FromList {
+        public abstract boolean getBoolean(List list, int i);
+    }
+
+    public abstract class FromStructToFloat extends FromStruct {
+        public abstract float getFloat(Struct struct);
+    }
+
+    public abstract class FromListToFloat extends FromList {
+        public abstract float getFloat(List list, int i);
+    }
+
+    public abstract class FromStructToDouble extends FromStruct {
+        public abstract double getDouble(Struct struct);
+    }
+
+    public abstract class FromListToDouble extends FromList {
+        public abstract double getDouble(List list, int i);
+    }
+
+    public abstract class FromStructToStruct extends FromStruct {
+        public abstract java.util.List<Map.Entry<String, FromStruct>> getMembersGetters();
+
+        public abstract Struct getStruct(Struct struct);
+    }
+
+    public abstract class FromListToStruct extends FromList {
+        public abstract java.util.List<Map.Entry<String, FromStruct>> getMembersGetters();
+
+        public abstract Struct getStruct(List list, int i);
+    }
+
+    public abstract class FromStructToList extends FromStruct {
+        public abstract FromList getElementGetter();
+
+        public abstract List getList(Struct struct);
+    }
+
+    public abstract class FromListToList extends FromList {
+        public abstract FromList getElementGetter();
+
+        public abstract List getList(List list, int i);
+    }
+
+    public abstract class FromStructToDict extends FromStruct {
+        public abstract FromDict getGetter();
+
+        public abstract Dict getDict(Struct struct);
+    }
+
+    public abstract class FromListToDict extends FromList {
+        public abstract FromDict getGetter();
+
+        public abstract Dict getDict(List list, int i);
+    }
+
+    public abstract class FromStructToBigDecimal extends FromStruct {
+        public abstract BigDecimal getBigDecimal(Struct struct);
+    }
+
+    public abstract class FromListToBigDecimal extends FromList {
+        public abstract BigDecimal getBigDecimal(List list, int i);
+    }
+}

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/format/YtOutputWriter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/format/YtOutputWriter.scala
@@ -5,21 +5,23 @@ import org.apache.spark.executor.TaskMetricUpdater
 import org.apache.spark.metrics.yt.YtMetricsRegister
 import org.apache.spark.metrics.yt.YtMetricsRegister.ytMetricsSource._
 import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.execution.datasources.OutputWriter
 import org.apache.spark.sql.types.StructType
 import org.slf4j.LoggerFactory
+import tech.ytsaurus.client.request.{TransactionalOptions, WriteTable}
+import tech.ytsaurus.client.{ArrowWriteSerializationContext, CompoundClient, InternalRowYTGetters, TableWriter}
+import tech.ytsaurus.core.GUID
+import tech.ytsaurus.spyt.format.conf.SparkYtWriteConfiguration
 import tech.ytsaurus.spyt.format.conf.YtTableSparkSettings._
 import tech.ytsaurus.spyt.fs.conf._
 import tech.ytsaurus.spyt.fs.path.YPathEnriched
 import tech.ytsaurus.spyt.serializers.{InternalRowSerializer, WriteSchemaConverter}
 import tech.ytsaurus.spyt.wrapper.LogLazy
-import tech.ytsaurus.client.request.{TransactionalOptions, WriteSerializationContext, WriteTable}
-import tech.ytsaurus.client.{CompoundClient, TableWriter}
-import tech.ytsaurus.core.GUID
-import tech.ytsaurus.spyt.format.conf.SparkYtWriteConfiguration
 
 import java.util
 import java.util.concurrent.{CompletableFuture, TimeUnit}
+import scala.collection.JavaConverters.seqAsJavaListConverter
 import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Try}
 
@@ -151,9 +153,15 @@ class YtOutputWriter(richPath: YPathEnriched,
   protected def initializeWriter(): TableWriter[InternalRow] = {
     val appendPath = richPath.withAttr("append", "true").toYPath
     log.debugLazy(s"Initialize new write: $appendPath, transaction: $transactionGuid")
+    val internalRowGetters = new InternalRowYTGetters()
     val request = WriteTable.builder[InternalRow]()
       .setPath(appendPath)
-      .setSerializationContext(new WriteSerializationContext(new InternalRowSerializer(schema, WriteSchemaConverter(options))))
+      .setSerializationContext(new ArrowWriteSerializationContext[InternalRow, ArrayData, MapData, InternalRowYTGetters](
+        WriteSchemaConverter(options).ytLogicalTypeStruct(schema).fields.zipWithIndex.map {
+          case ((name, ytLogicalType, _), i) =>
+            util.Map.entry(name, ytLogicalType.ytGettersFromStruct(internalRowGetters, i))
+        }.asJava
+      ))
       .setTransactionalOptions(new TransactionalOptions(GUID.valueOf(transactionGuid)))
       .setNeedRetries(false)
       .build()

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/InternalRowSerializer.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/InternalRowSerializer.scala
@@ -3,143 +3,15 @@ package tech.ytsaurus.spyt.serializers
 import org.apache.spark.metrics.yt.YtMetricsRegister
 import org.apache.spark.metrics.yt.YtMetricsRegister.ytMetricsSource._
 import org.apache.spark.sql.catalyst.InternalRow
-import org.apache.spark.sql.sources.Filter
-import org.apache.spark.sql.spyt.types._
-import org.apache.spark.sql.types._
-import org.slf4j.LoggerFactory
 import tech.ytsaurus.client.TableWriter
-import tech.ytsaurus.client.rows.{WireProtocolWriteable, WireRowSerializer}
-import tech.ytsaurus.core.tables.{ColumnValueType, TableSchema}
-import tech.ytsaurus.spyt.format.conf.YtTableSparkSettings.{WriteSchemaHint, WriteTypeV3}
-import tech.ytsaurus.spyt.serialization.YsonEncoder
-import tech.ytsaurus.spyt.serializers.InternalRowSerializer._
-import tech.ytsaurus.spyt.serializers.SchemaConverter.{Unordered, decimalToBinary}
-import tech.ytsaurus.spyt.types.YTsaurusTypes
-import tech.ytsaurus.spyt.wrapper.LogLazy
-import tech.ytsaurus.typeinfo.TiType
 
 import java.util.concurrent.{Executors, TimeUnit}
 import scala.annotation.tailrec
-import scala.collection.mutable
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
-class InternalRowSerializer(schema: StructType, writeSchemaConverter: WriteSchemaConverter) extends WireRowSerializer[InternalRow] with LogLazy {
-
-  private val log = LoggerFactory.getLogger(getClass)
-
-  private val tableSchema = writeSchemaConverter.tableSchema(schema, Unordered)
-
-  override def getSchema: TableSchema = tableSchema
-
-  private def getColumnType(i: Int): ColumnValueType = {
-    def isComposite(t: TiType): Boolean = t.isList || t.isDict || t.isStruct || t.isTuple || t.isVariant
-
-    if (writeSchemaConverter.typeV3Format) {
-      val column = tableSchema.getColumnSchema(i)
-      val t = column.getTypeV3
-      if (t.isOptional) {
-        val inner = t.asOptional().getItem
-        if (inner.isOptional || isComposite(inner)) {
-          ColumnValueType.COMPOSITE
-        } else {
-          column.getType
-        }
-      } else if (isComposite(t)) {
-        ColumnValueType.COMPOSITE
-      } else {
-        column.getType
-      }
-    } else {
-      tableSchema.getColumnType(i)
-    }
-  }
-
-  override def serializeRow(row: InternalRow,
-                            writeable: WireProtocolWriteable,
-                            keyFieldsOnly: Boolean,
-                            aggregate: Boolean,
-                            idMapping: Array[Int]): Unit = {
-    writeable.writeValueCount(row.numFields)
-    for {
-      i <- 0 until row.numFields
-    } {
-      if (row.isNullAt(i)) {
-        writeable.writeValueHeader(valueId(i, idMapping), ColumnValueType.NULL, aggregate, 0)
-      } else {
-        val sparkField = schema(i)
-        val ytFieldHint = if (writeSchemaConverter.typeV3Format) Some(tableSchema.getColumnSchema(i).getTypeV3) else None
-        sparkField.dataType match {
-          case BinaryType =>
-            writeBytes(writeable, idMapping, aggregate, i, row.getBinary(i), getColumnType)
-          case StringType =>
-            writeBytes(writeable, idMapping, aggregate, i, row.getUTF8String(i).getBytes, getColumnType)
-          case d: DecimalType =>
-            val value = row.getDecimal(i, d.precision, d.scale)
-            if (writeSchemaConverter.typeV3Format) {
-              val binary = decimalToBinary(ytFieldHint, d, value)
-              writeBytes(writeable, idMapping, aggregate, i, binary, getColumnType)
-            } else {
-              val targetColumnType = getColumnType(i)
-              targetColumnType match {
-                case ColumnValueType.INT64 | ColumnValueType.UINT64 | ColumnValueType.DOUBLE | ColumnValueType.STRING =>
-                  writeHeader(writeable, idMapping, aggregate, i, 0, _ => targetColumnType)
-                  targetColumnType match {
-                    case ColumnValueType.INT64 | ColumnValueType.UINT64 =>
-                      writeable.onInteger(value.toLong)
-                    case ColumnValueType.DOUBLE =>
-                      writeable.onDouble(value.toDouble)
-                    case ColumnValueType.STRING =>
-                      writeable.onBytes(value.toString().getBytes)
-                  }
-                case _ =>
-                  throw new IllegalArgumentException("Writing decimal type without enabled type_v3 is not supported")
-              }
-            }
-          case t@(ArrayType(_, _) | StructType(_) | MapType(_, _, _)) =>
-            val skipNulls = sparkField.metadata.contains("skipNulls") && sparkField.metadata.getBoolean("skipNulls")
-            writeBytes(writeable, idMapping, aggregate, i,
-              YsonEncoder.encode(row.get(i, sparkField.dataType), t, skipNulls, writeSchemaConverter.typeV3Format, ytFieldHint),
-              getColumnType)
-          case otherType =>
-            val isExtendedType = YTsaurusTypes
-              .instance
-              .wireWriteRow(otherType, row, writeable, aggregate, idMapping, i, getColumnType)
-            if (!isExtendedType) {
-              writeHeader(writeable, idMapping, aggregate, i, 0, getColumnType)
-              otherType match {
-                case ByteType => writeable.onInteger(row.getByte(i))
-                case ShortType => writeable.onInteger(row.getShort(i))
-                case IntegerType => writeable.onInteger(row.getInt(i))
-                case LongType => writeable.onInteger(row.getLong(i))
-                case BooleanType => writeable.onBoolean(row.getBoolean(i))
-                case FloatType => writeable.onDouble(row.getFloat(i))
-                case DoubleType => writeable.onDouble(row.getDouble(i))
-                case DateType => writeable.onInteger(row.getLong(i))
-                case _: DatetimeType => writeable.onInteger(row.getLong(i))
-                case TimestampType => writeable.onInteger(row.getLong(i))
-                case _: Date32Type => writeable.onInteger(row.getInt(i))
-                case _: Datetime64Type => writeable.onInteger(row.getLong(i))
-                case _: Timestamp64Type => writeable.onInteger(row.getLong(i))
-                case _: Interval64Type => writeable.onInteger(row.getLong(i))
-              }
-            }
-        }
-      }
-    }
-  }
-}
-
 object InternalRowSerializer {
-  private val deserializers: ThreadLocal[mutable.Map[StructType, InternalRowSerializer]] = ThreadLocal.withInitial(() => mutable.ListMap.empty)
   private val context = ExecutionContext.fromExecutor(Executors.newFixedThreadPool(4))
-
-  def getOrCreate(schema: StructType,
-                  schemaHint: Map[String, YtLogicalType],
-                  filters: Array[Filter] = Array.empty,
-                  typeV3Format: Boolean = false): InternalRowSerializer = {
-    deserializers.get().getOrElseUpdate(schema, new InternalRowSerializer(schema, new WriteSchemaConverter(schemaHint, typeV3Format)))
-  }
 
   final def writeRows(writer: TableWriter[InternalRow],
                       rows: java.util.ArrayList[InternalRow],
@@ -159,23 +31,6 @@ object InternalRowSerializer {
       }
       writeRowsRecursive(writer, rows, timeout)
     }
-  }
-
-  private def valueId(id: Int, idMapping: Array[Int]): Int = {
-    if (idMapping != null) {
-      idMapping(id)
-    } else id
-  }
-
-  def writeHeader(writeable: WireProtocolWriteable, idMapping: Array[Int], aggregate: Boolean,
-                          i: Int, length: Int, getColumnType: Int => ColumnValueType): Unit = {
-    writeable.writeValueHeader(valueId(i, idMapping), getColumnType(i), aggregate, length)
-  }
-
-  def writeBytes(writeable: WireProtocolWriteable, idMapping: Array[Int], aggregate: Boolean,
-                         i: Int, bytes: Array[Byte], getColumnType: Int => ColumnValueType): Unit = {
-    writeHeader(writeable, idMapping, aggregate, i, bytes.length, getColumnType)
-    writeable.onBytes(bytes)
   }
 }
 

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/WriteSchemaConverter.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/WriteSchemaConverter.scala
@@ -58,9 +58,10 @@ class WriteSchemaConverter(
     case BooleanType => YtLogicalType.Boolean
     case d: DecimalType =>
       val dT = if (d.precision > 35) applyYtLimitToSparkDecimal(d) else d
-      YtLogicalType.Decimal(dT.precision, dT.scale)
+      YtLogicalType.Decimal(dT.precision, dT.scale, d)
     case aT: ArrayType =>
       YtLogicalType.Array(wrapSparkAttributes(ytLogicalTypeV3(aT.elementType), aT.containsNull))
+    case _: StructType if hint != null => hint
     case sT: StructType if isTuple(sT) =>
       YtLogicalType.Tuple {
         sT.fields.map(tF =>

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YtLogicalType.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YtLogicalType.scala
@@ -1,21 +1,50 @@
 package tech.ytsaurus.spyt.serializers
 
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.util.{ArrayData, MapData}
 import org.apache.spark.sql.spyt.types._
 import org.apache.spark.sql.types._
+import tech.ytsaurus.client.{InternalRowYTGetters, YTGetters}
 import tech.ytsaurus.core.tables.ColumnValueType
 import tech.ytsaurus.spyt.serializers.SchemaConverter.MetadataFields
+import tech.ytsaurus.spyt.serializers.YsonRowConverter.{isNull, serializeValue}
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Binary.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Boolean.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Date.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Datetime.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Double.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Float.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Int16.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Int32.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Int64.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Int8.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Interval.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Null.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.String.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Timestamp.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Uint32.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Uint64.tiType
+import tech.ytsaurus.spyt.serializers.YtLogicalType.Utf8.tiType
 import tech.ytsaurus.typeinfo.StructType.Member
 import tech.ytsaurus.typeinfo.{TiType, TypeName}
+import tech.ytsaurus.yson.YsonConsumer
+import tech.ytsaurus.ysontree.YTreeBinarySerializer
 
+import java.io.ByteArrayInputStream
+import java.nio.ByteBuffer
 import scala.annotation.tailrec
 
 sealed trait SparkType {
   def topLevel: DataType
+
   def innerLevel: DataType
 }
+
 case class SingleSparkType(topLevel: DataType) extends SparkType {
   override def innerLevel: DataType = topLevel
 }
+
 case class TopInnerSparkTypes(topLevel: DataType, innerLevel: DataType) extends SparkType
 
 sealed trait YtLogicalType {
@@ -48,10 +77,15 @@ sealed trait YtLogicalType {
   def alias: YtLogicalTypeAlias
 
   def arrowSupported: Boolean = true
+
+  def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList
+
+  def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct
 }
 
 sealed trait YtLogicalTypeAlias {
   def name: String = aliases.head
+
   def aliases: Seq[String]
 }
 
@@ -69,6 +103,7 @@ sealed abstract class AtomicYtLogicalType(name: String,
     this(name, value, columnValueType, tiType, SingleSparkType(sparkType), otherAliases, arrowSupported)
 
   override def alias: YtLogicalTypeAlias = this
+
   override def aliases: Seq[String] = name +: otherAliases
 }
 
@@ -84,60 +119,591 @@ sealed abstract class CompositeYtLogicalTypeAlias(name: String,
 }
 
 object YtLogicalType {
+
   import tech.ytsaurus.spyt.types.YTsaurusTypes.instance.sparkTypeFor
 
-  case object Null extends AtomicYtLogicalType("null", 0x02, ColumnValueType.NULL, TiType.nullType(), NullType)
+  case object Null extends AtomicYtLogicalType("null", 0x02, ColumnValueType.NULL, TiType.nullType(), NullType) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToNull {
+      override def getTiType: TiType = tiType
 
-  case object Int64 extends AtomicYtLogicalType("int64", 0x03, ColumnValueType.INT64, TiType.int64(), LongType)
-  case object Uint64 extends AtomicYtLogicalType("uint64", 0x04, ColumnValueType.UINT64, TiType.uint64(), sparkTypeFor(TiType.uint64()))
-  case object Float extends AtomicYtLogicalType("float", 0x05, ColumnValueType.DOUBLE, TiType.floatType(),
-    TopInnerSparkTypes(FloatType, DoubleType), Seq.empty, arrowSupported = false)
-  case object Double extends AtomicYtLogicalType("double", 0x05, ColumnValueType.DOUBLE, TiType.doubleType(), DoubleType)
-  case object Boolean extends AtomicYtLogicalType("boolean", 0x06, ColumnValueType.BOOLEAN, TiType.bool(), BooleanType, Seq("bool"))
+      override def getSize(list: ArrayData): Int = list.numElements()
 
-  case object String extends AtomicYtLogicalType("string", 0x10, ColumnValueType.STRING, TiType.string(), StringType)
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onEntity()
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct =
+      new ytGetter.FromStructToNull {
+        override def getTiType: TiType = tiType
+
+        override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onEntity()
+      }
+  }
+
+  case object Int64 extends AtomicYtLogicalType("int64", 0x03, ColumnValueType.INT64, TiType.int64(), LongType) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToLong {
+      override def getLong(list: ArrayData, i: Int): Long = list.getLong(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onInteger(list.getLong(i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToLong {
+      override def getLong(struct: InternalRow): Long = struct.getLong(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onInteger(struct.getLong(ordinal))
+    }
+  }
+
+  case object Uint64 extends AtomicYtLogicalType("uint64", 0x04, ColumnValueType.UINT64, TiType.uint64(), sparkTypeFor(TiType.uint64())) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToLong {
+      override def getLong(list: ArrayData, i: Int): Long = list.getLong(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onUnsignedInteger(getLong(list, i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToLong {
+      override def getLong(struct: InternalRow): Long = struct.getLong(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onUnsignedInteger(getLong(struct))
+    }
+  }
+
+  case object Float extends AtomicYtLogicalType(
+    "float", 0x05, ColumnValueType.DOUBLE, TiType.floatType(),
+    TopInnerSparkTypes(FloatType, DoubleType), Seq.empty, arrowSupported = false,
+  ) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToFloat {
+      override def getFloat(list: ArrayData, i: Int): Float = list.getFloat(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onDouble(getFloat(list, i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToFloat {
+      override def getFloat(struct: InternalRow): Float = struct.getFloat(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onDouble(getFloat(struct))
+    }
+  }
+
+  case object Double extends AtomicYtLogicalType("double", 0x05, ColumnValueType.DOUBLE, TiType.doubleType(), DoubleType) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToDouble {
+      override def getDouble(list: ArrayData, i: Int): Double = list.getDouble(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onDouble(getDouble(list, i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToDouble {
+      override def getDouble(struct: InternalRow): Double = struct.getDouble(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onDouble(getDouble(struct))
+    }
+  }
+
+  case object Boolean extends AtomicYtLogicalType("boolean", 0x06, ColumnValueType.BOOLEAN, TiType.bool(), BooleanType, Seq("bool")) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToBoolean {
+      override def getBoolean(list: ArrayData, i: Int): Boolean = list.getBoolean(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onBoolean(list.getBoolean(i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToBoolean {
+      override def getBoolean(struct: InternalRow): Boolean = struct.getBoolean(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onBoolean(struct.getBoolean(ordinal))
+    }
+  }
+
+  private def getBytes(byteBuffer: ByteBuffer): scala.Array[Byte] = {
+    val bytes = new scala.Array[Byte](byteBuffer.remaining())
+    byteBuffer.get(bytes)
+    bytes
+  }
+
+  case object String extends AtomicYtLogicalType("string", 0x10, ColumnValueType.STRING, TiType.string(), StringType) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToString {
+      override def getString(list: ArrayData, i: Int): ByteBuffer = list.getUTF8String(i).getByteBuffer
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = {
+        val bytes = getBytes(getString(list, i))
+        ysonConsumer.onString(bytes, 0, bytes.length)
+      }
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToString {
+      override def getString(struct: InternalRow): ByteBuffer = struct.getUTF8String(ordinal).getByteBuffer
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = {
+        val bytes = getBytes(getString(struct))
+        ysonConsumer.onString(bytes, 0, bytes.length)
+      }
+    }
+  }
+
   case object Binary extends AtomicYtLogicalType("binary", 0x10, ColumnValueType.STRING, TiType.string(), BinaryType) {
     override def getName(isColumnType: Boolean): String = columnValueType.getName
 
     override def getNameV3(inner: Boolean): String = {
       if (inner) alias.name else "string"
     }
+
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToString {
+      override def getString(list: ArrayData, i: Int): ByteBuffer = ByteBuffer.wrap(list.getBinary(i))
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = {
+        val byteBuffer = getString(list, i)
+        val bytes = new scala.Array[Byte](byteBuffer.remaining())
+        byteBuffer.get(bytes)
+        ysonConsumer.onString(bytes, 0, bytes.length)
+      }
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToString {
+      override def getString(struct: InternalRow): ByteBuffer = ByteBuffer.wrap(struct.getBinary(ordinal))
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = {
+        val byteBuffer = getString(struct)
+        val bytes = new scala.Array[Byte](byteBuffer.remaining())
+        byteBuffer.get(bytes)
+        ysonConsumer.onString(bytes, 0, bytes.length)
+      }
+    }
   }
+
   case object Any extends AtomicYtLogicalType("any", 0x11, ColumnValueType.ANY, TiType.yson(), sparkTypeFor(TiType.yson()), Seq("yson")) {
     override def nullable: Boolean = true
+
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToYson {
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        YTreeBinarySerializer.deserialize(new ByteArrayInputStream(list.getBinary(i)), ysonConsumer)
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToYson {
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        YTreeBinarySerializer.deserialize(new ByteArrayInputStream(struct.getBinary(ordinal)), ysonConsumer)
+    }
   }
 
-  case object Int8 extends AtomicYtLogicalType("int8", 0x1000, ColumnValueType.INT64, TiType.int8(), ByteType)
-  case object Uint8 extends AtomicYtLogicalType("uint8", 0x1001, ColumnValueType.INT64, TiType.uint8(), ShortType)
+  case object Int8 extends AtomicYtLogicalType("int8", 0x1000, ColumnValueType.INT64, TiType.int8(), ByteType) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToByte {
+      override def getByte(list: ArrayData, i: Int): Byte = list.getByte(i)
 
-  case object Int16 extends AtomicYtLogicalType("int16", 0x1003, ColumnValueType.INT64, TiType.int16(), ShortType)
-  case object Uint16 extends AtomicYtLogicalType("uint16", 0x1004, ColumnValueType.INT64, TiType.uint16(), IntegerType)
+      override def getSize(list: ArrayData): Int = list.numElements()
 
-  case object Int32 extends AtomicYtLogicalType("int32", 0x1005, ColumnValueType.INT64, TiType.int32(), IntegerType)
-  case object Uint32 extends AtomicYtLogicalType("uint32", 0x1006, ColumnValueType.INT64, TiType.uint32(), LongType)
+      override def getTiType: TiType = tiType
 
-  case object Utf8 extends AtomicYtLogicalType("utf8", 0x1007, ColumnValueType.STRING, TiType.utf8(), StringType)
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onInteger(list.getByte(i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToByte {
+      override def getByte(struct: InternalRow): Byte = struct.getByte(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onInteger(struct.getByte(ordinal))
+    }
+  }
+
+  case object Uint8 extends AtomicYtLogicalType("uint8", 0x1001, ColumnValueType.INT64, TiType.uint8(), ShortType) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToByte {
+      override def getByte(list: ArrayData, i: Int): Byte = list.getShort(i).toByte
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onUnsignedInteger(getByte(list, i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToByte {
+      override def getByte(struct: InternalRow): Byte = struct.getShort(ordinal).toByte
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onUnsignedInteger(getByte(struct))
+    }
+  }
+
+  case object Int16 extends AtomicYtLogicalType("int16", 0x1003, ColumnValueType.INT64, TiType.int16(), ShortType) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToShort {
+      override def getShort(list: ArrayData, i: Int): Short = list.getShort(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onInteger(list.getShort(i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToShort {
+      override def getShort(struct: InternalRow): Short = struct.getShort(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onInteger(struct.getShort(ordinal))
+    }
+  }
+
+  case object Uint16 extends AtomicYtLogicalType("uint16", 0x1004, ColumnValueType.INT64, TiType.uint16(), IntegerType) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToShort {
+      override def getShort(list: ArrayData, i: Int): Short = list.getInt(i).toShort
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onUnsignedInteger(getShort(list, i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToShort {
+      override def getShort(struct: InternalRow): Short = struct.getInt(ordinal).toShort
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onUnsignedInteger(getShort(struct))
+    }
+  }
+
+  case object Int32 extends AtomicYtLogicalType("int32", 0x1005, ColumnValueType.INT64, TiType.int32(), IntegerType) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToInt {
+      override def getInt(list: ArrayData, i: Int): Int = list.getInt(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onInteger(list.getInt(i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToInt {
+      override def getInt(struct: InternalRow): Int = struct.getInt(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onInteger(struct.getInt(ordinal))
+    }
+  }
+
+  case object Uint32 extends AtomicYtLogicalType("uint32", 0x1006, ColumnValueType.INT64, TiType.uint32(), LongType) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToInt {
+      override def getInt(list: ArrayData, i: Int): Int = list.getLong(i).toInt
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onUnsignedInteger(getInt(list, i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToInt {
+      override def getInt(struct: InternalRow): Int = struct.getLong(ordinal).toInt
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onUnsignedInteger(getInt(struct))
+    }
+  }
+
+  case object Utf8 extends AtomicYtLogicalType("utf8", 0x1007, ColumnValueType.STRING, TiType.utf8(), StringType) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToString {
+      override def getString(list: ArrayData, i: Int): ByteBuffer = list.getUTF8String(i).getByteBuffer
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = {
+        val bytes = getBytes(list.getUTF8String(i).getByteBuffer)
+        ysonConsumer.onString(bytes, 0, bytes.length)
+      }
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToString {
+      override def getString(struct: InternalRow): ByteBuffer = struct.getUTF8String(ordinal).getByteBuffer
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = {
+        val bytes = getBytes(struct.getUTF8String(ordinal).getByteBuffer)
+        ysonConsumer.onString(bytes, 0, bytes.length)
+      }
+    }
+  }
 
   // Unsupported types are listed here: yt/yt/client/arrow/arrow_row_stream_encoder.cpp
-  case object Date extends AtomicYtLogicalType("date", 0x1008, ColumnValueType.UINT64, TiType.date(), DateType, arrowSupported = false)
-  case object Datetime extends AtomicYtLogicalType("datetime", 0x1009, ColumnValueType.UINT64, TiType.datetime(), new DatetimeType(), arrowSupported = false)
-  case object Timestamp extends AtomicYtLogicalType("timestamp", 0x100a, ColumnValueType.UINT64, TiType.timestamp(), TimestampType, arrowSupported = false)
-  case object Interval extends AtomicYtLogicalType("interval", 0x100b, ColumnValueType.INT64, TiType.interval(), LongType, arrowSupported = false)
+  case object Date extends AtomicYtLogicalType("date", 0x1008, ColumnValueType.UINT64, TiType.date(), DateType, arrowSupported = false) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToInt {
+      override def getInt(list: ArrayData, i: Int): Int = list.getInt(i)
 
-  case object Void extends AtomicYtLogicalType("void", 0x100c, ColumnValueType.NULL, TiType.voidType(), NullType) //?
+      override def getSize(list: ArrayData): Int = list.numElements()
 
-  case object Date32 extends AtomicYtLogicalType("date32", 0x1018, ColumnValueType.INT64, TiType.date32(), new Date32Type(), arrowSupported = false)
-  case object Datetime64 extends AtomicYtLogicalType("datetime64", 0x1019, ColumnValueType.INT64, TiType.datetime64(), new Datetime64Type(), arrowSupported = false)
-  case object Timestamp64 extends AtomicYtLogicalType("timestamp64", 0x101a, ColumnValueType.INT64, TiType.timestamp64(), new Timestamp64Type(), arrowSupported = false)
-  case object Interval64 extends AtomicYtLogicalType("interval64", 0x101b, ColumnValueType.INT64, TiType.interval64(), new Interval64Type(), arrowSupported = false)
+      override def getTiType: TiType = tiType
 
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onUnsignedInteger(getInt(list, i))
+    }
 
-  case class Decimal(precision: Int, scale: Int) extends CompositeYtLogicalType {
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToInt {
+      override def getInt(struct: InternalRow): Int = struct.getInt(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onUnsignedInteger(getInt(struct))
+    }
+  }
+
+  case object Datetime extends AtomicYtLogicalType("datetime", 0x1009, ColumnValueType.UINT64, TiType.datetime(), new DatetimeType(), arrowSupported = false) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToLong {
+      override def getLong(list: ArrayData, i: Int): Long = list.getLong(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onUnsignedInteger(getLong(list, i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToLong {
+      override def getLong(struct: InternalRow): Long = struct.getLong(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onUnsignedInteger(getLong(struct))
+    }
+  }
+
+  case object Timestamp extends AtomicYtLogicalType("timestamp", 0x100a, ColumnValueType.UINT64, TiType.timestamp(), TimestampType, arrowSupported = false) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToLong {
+      override def getLong(list: ArrayData, i: Int): Long = list.getLong(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onUnsignedInteger(getLong(list, i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToLong {
+      override def getLong(struct: InternalRow): Long = struct.getLong(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onUnsignedInteger(getLong(struct))
+    }
+  }
+
+  case object Interval extends AtomicYtLogicalType("interval", 0x100b, ColumnValueType.INT64, TiType.interval(), LongType, arrowSupported = false) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToLong {
+      override def getLong(list: ArrayData, i: Int): Long = list.getLong(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onInteger(getLong(list, i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToLong {
+      override def getLong(struct: InternalRow): Long = struct.getLong(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onInteger(getLong(struct))
+    }
+  }
+
+  case object Void extends AtomicYtLogicalType("void", 0x100c, ColumnValueType.NULL, TiType.voidType(), NullType) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToNull {
+      override def getTiType: TiType = tiType
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onEntity()
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct =
+      new ytGetter.FromStructToNull {
+        override def getTiType: TiType = tiType
+
+        override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = ysonConsumer.onEntity()
+      }
+  }
+
+  case object Date32 extends AtomicYtLogicalType("date32", 0x1018, ColumnValueType.INT64, TiType.date32(), new Date32Type(), arrowSupported = false) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToInt {
+      override def getInt(list: ArrayData, i: Int): Int = list.getInt(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onUnsignedInteger(getInt(list, i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToInt {
+      override def getInt(struct: InternalRow): Int = struct.getInt(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onUnsignedInteger(getInt(struct))
+    }
+  }
+
+  case object Datetime64 extends AtomicYtLogicalType("datetime64", 0x1019, ColumnValueType.INT64, TiType.datetime64(), new Datetime64Type(), arrowSupported = false) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToLong {
+      override def getLong(list: ArrayData, i: Int): Long = list.getLong(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onUnsignedInteger(getLong(list, i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToLong {
+      override def getLong(struct: InternalRow): Long = struct.getLong(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onUnsignedInteger(getLong(struct))
+    }
+  }
+
+  case object Timestamp64 extends AtomicYtLogicalType("timestamp64", 0x101a, ColumnValueType.INT64, TiType.timestamp64(), new Timestamp64Type(), arrowSupported = false) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToLong {
+      override def getLong(list: ArrayData, i: Int): Long = list.getLong(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onUnsignedInteger(getLong(list, i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToLong {
+      override def getLong(struct: InternalRow): Long = struct.getLong(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onUnsignedInteger(getLong(struct))
+    }
+  }
+
+  case object Interval64 extends AtomicYtLogicalType("interval64", 0x101b, ColumnValueType.INT64, TiType.interval64(), new Interval64Type(), arrowSupported = false) {
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToLong {
+      override def getLong(list: ArrayData, i: Int): Long = list.getLong(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onInteger(getLong(list, i))
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToLong {
+      override def getLong(struct: InternalRow): Long = struct.getLong(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        ysonConsumer.onInteger(getLong(struct))
+    }
+  }
+
+  case class Decimal(precision: Int, scale: Int, decimalType: DecimalType) extends CompositeYtLogicalType {
     override def sparkType: SparkType = SingleSparkType(DecimalType(precision, scale))
 
     override def alias: CompositeYtLogicalTypeAlias = Decimal
 
     override def tiType: TiType = TiType.decimal(precision, scale)
+
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToBigDecimal {
+      override def getBigDecimal(list: ArrayData, i: Int): java.math.BigDecimal =
+        list.getDecimal(i, decimalType.precision, decimalType.scale).toJavaBigDecimal.setScale(scale)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = {
+        val bytes = getBigDecimal(list, i).unscaledValue().toByteArray
+        ysonConsumer.onString(bytes, 0, bytes.length)
+      }
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToBigDecimal {
+      override def getBigDecimal(struct: InternalRow): java.math.BigDecimal =
+        struct.getDecimal(ordinal, decimalType.precision, decimalType.scale).toJavaBigDecimal.setScale(scale)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = {
+        val bytes = getBigDecimal(struct).unscaledValue().toByteArray
+        ysonConsumer.onString(bytes, 0, bytes.length)
+      }
+    }
   }
 
   case object Decimal extends CompositeYtLogicalTypeAlias("decimal")
@@ -158,6 +724,54 @@ object YtLogicalType {
     override def alias: CompositeYtLogicalTypeAlias = Optional
 
     override def arrowSupported: Boolean = inner.arrowSupported
+
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToOptional {
+      private val notEmptyGetter = inner.ytGettersFromList(ytGetter)
+
+      override def getNotEmptyGetter: ytGetter.FromList = notEmptyGetter
+
+      override def isEmpty(list: ArrayData, i: Int): Boolean = list.isNullAt(i)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = {
+        if (list.isNullAt(i)) {
+          ysonConsumer.onEntity()
+        } else if (inner.isInstanceOf[Optional]) {
+          ysonConsumer.onBeginList()
+          ysonConsumer.onListItem()
+          notEmptyGetter.getYson(list, i, ysonConsumer)
+          ysonConsumer.onEndList()
+        } else {
+          notEmptyGetter.getYson(list, i, ysonConsumer)
+        }
+      }
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToOptional {
+      private val notEmptyGetter = inner.ytGettersFromStruct(ytGetter, ordinal)
+
+      override def getNotEmptyGetter: ytGetter.FromStruct = notEmptyGetter
+
+      override def isEmpty(struct: InternalRow): Boolean = struct.isNullAt(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = {
+        if (struct.isNullAt(ordinal)) {
+          ysonConsumer.onEntity()
+        } else if (inner.isInstanceOf[Optional]) {
+          ysonConsumer.onBeginList()
+          ysonConsumer.onListItem()
+          notEmptyGetter.getYson(struct, ysonConsumer)
+          ysonConsumer.onEndList()
+        } else {
+          notEmptyGetter.getYson(struct, ysonConsumer)
+        }
+      }
+    }
   }
 
   case object Optional extends CompositeYtLogicalTypeAlias(TypeName.Optional.getWireName)
@@ -172,19 +786,129 @@ object YtLogicalType {
       MapType(dictKey.sparkType.innerLevel, dictValue.sparkType.innerLevel, dictValue.nullable)
     )
 
+    private def newGetter(ytGetter: InternalRowYTGetters): ytGetter.FromDict = new ytGetter.FromDict {
+      private val keyGetter = dictKey.ytGettersFromList(ytGetter)
+      private val valueGetter = dictValue.ytGettersFromList(ytGetter)
+
+      override def getKeyGetter: ytGetter.FromList = keyGetter
+
+      override def getValueGetter: ytGetter.FromList = valueGetter
+
+      override def getSize(dict: MapData): Int = dict.numElements()
+
+      override def getKeys(dict: MapData): ArrayData = dict.keyArray()
+
+      override def getValues(dict: MapData): ArrayData = dict.valueArray()
+
+      override def getTiType: TiType = tiType
+    }
+
+    def newYsonSerializer(getter: InternalRowYTGetters#FromDict): (MapData, YsonConsumer) => Unit = {
+      val keyGetter = getter.getKeyGetter
+      val valueGetter = getter.getValueGetter
+      (dict, ysonConsumer) => {
+        ysonConsumer.onBeginList()
+        val keys = dict.keyArray()
+        val values = dict.valueArray()
+        for (i <- 0 until dict.numElements()) {
+          ysonConsumer.onListItem()
+          ysonConsumer.onBeginList()
+          ysonConsumer.onListItem()
+          keyGetter.getYson(keys, i, ysonConsumer)
+          ysonConsumer.onListItem()
+          valueGetter.getYson(values, i, ysonConsumer)
+          ysonConsumer.onEndList()
+        }
+        ysonConsumer.onEndList()
+      }
+    }
+
     override def tiType: TiType = TiType.dict(dictKey.tiType, dictValue.tiType)
 
     override def alias: CompositeYtLogicalTypeAlias = Dict
+
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToDict {
+      private val getter = newGetter(ytGetter)
+      private val ysonSerializer = newYsonSerializer(getter)
+
+      override def getGetter(): ytGetter.FromDict = getter
+
+      override def getTiType: TiType = tiType
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getDict(list: ArrayData, i: Int): MapData = list.getMap(i)
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        ysonSerializer(list.getMap(i), ysonConsumer)
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToDict {
+      private val getter = newGetter(ytGetter)
+      private val ysonSerializer = newYsonSerializer(getter)
+
+      override def getGetter(): ytGetter.FromDict = getter
+
+      override def getDict(struct: InternalRow): MapData = struct.getMap(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        ysonSerializer(struct.getMap(ordinal), ysonConsumer)
+    }
   }
 
   case object Dict extends CompositeYtLogicalTypeAlias(TypeName.Dict.getWireName)
 
   case class Array(inner: YtLogicalType) extends CompositeYtLogicalType {
-    override def sparkType: SparkType = SingleSparkType( ArrayType(inner.sparkType.innerLevel, inner.nullable))
+    override def sparkType: SparkType = SingleSparkType(ArrayType(inner.sparkType.innerLevel, inner.nullable))
 
     override def tiType: TiType = TiType.list(inner.tiType)
 
     override def alias: CompositeYtLogicalTypeAlias = Array
+
+
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToList {
+      val elementGetter: ytGetter.FromList = inner.ytGettersFromList(ytGetter)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getElementGetter: ytGetter.FromList = elementGetter
+
+      override def getList(list: ArrayData, i: Int): ArrayData = list.getArray(i)
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = {
+        val value = list.getArray(i)
+        ysonConsumer.onBeginList()
+        for (j <- 0 until value.numElements()) {
+          ysonConsumer.onListItem()
+          elementGetter.getYson(value, j, ysonConsumer)
+        }
+        ysonConsumer.onEndList()
+      }
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToList {
+      val elementGetter: ytGetter.FromList = inner.ytGettersFromList(ytGetter)
+
+      override def getElementGetter: ytGetter.FromList = elementGetter
+
+      override def getList(struct: InternalRow): ArrayData = struct.getArray(ordinal)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = {
+        val value = struct.getArray(ordinal)
+        ysonConsumer.onBeginList()
+        for (j <- 0 until value.numElements()) {
+          ysonConsumer.onListItem()
+          elementGetter.getYson(value, j, ysonConsumer)
+        }
+        ysonConsumer.onEndList()
+      }
+    }
   }
 
   case object Array extends CompositeYtLogicalTypeAlias(TypeName.List.getWireName)
@@ -194,25 +918,121 @@ object YtLogicalType {
       .map { case (name, ytType, meta) => getStructField(name, ytType, meta, topLevel = false) }))
 
     import scala.collection.JavaConverters._
+
     override def tiType: TiType = TiType.struct(
-      fields.map{ case (name, ytType, _) => new Member(name, ytType.tiType)}.asJava
+      fields.map { case (name, ytType, _) => new Member(name, ytType.tiType) }.asJava
     )
 
     override def alias: CompositeYtLogicalTypeAlias = Struct
+
+    def newMembersGetters(ytGetter: InternalRowYTGetters): java.util.List[java.util.Map.Entry[String, ytGetter.FromStruct]] =
+      fields.zipWithIndex.map { case (field, i) =>
+        java.util.Map.entry(field._1, field._2.ytGettersFromStruct(ytGetter, i))
+      }.asJava
+
+    def yson(ytGetter: InternalRowYTGetters)(
+      membersGetters: java.util.List[java.util.Map.Entry[String, ytGetter.FromStruct]],
+      internalRow: InternalRow, ysonConsumer: YsonConsumer,
+    ): Unit = {
+      ysonConsumer.onBeginList()
+      for (i <- 0 until membersGetters.size()) {
+        ysonConsumer.onListItem()
+        membersGetters.get(i).getValue.getYson(internalRow, ysonConsumer)
+      }
+      ysonConsumer.onEndList()
+    }
+
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToStruct {
+      private val membersGetters = newMembersGetters(ytGetter)
+
+      override def getMembersGetters(): java.util.List[java.util.Map.Entry[String, ytGetter.FromStruct]] =
+        membersGetters
+
+      override def getStruct(list: ArrayData, i: Int): InternalRow = list.getStruct(i, fields.size)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        yson(ytGetter)(membersGetters, list.getStruct(i, membersGetters.size()), ysonConsumer)
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToStruct {
+      private val membersGetters = newMembersGetters(ytGetter)
+
+      override def getMembersGetters(): java.util.List[java.util.Map.Entry[String, ytGetter.FromStruct]] =
+        membersGetters
+
+      override def getStruct(struct: InternalRow): InternalRow = struct.getStruct(ordinal, fields.size)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        yson(ytGetter)(membersGetters, struct.getStruct(ordinal, membersGetters.size()), ysonConsumer)
+    }
   }
 
   case object Struct extends CompositeYtLogicalTypeAlias(TypeName.Struct.getWireName)
 
   case class Tuple(elements: Seq[(YtLogicalType, Metadata)]) extends CompositeYtLogicalType {
+    private val entries = elements.zipWithIndex.map { case ((ytType, _), index) => (s"_${1 + index}", ytType) }
     override def sparkType: SparkType = SingleSparkType(StructType(elements.zipWithIndex
       .map { case ((ytType, meta), index) => getStructField(s"_${1 + index}", ytType, meta, topLevel = false) }))
 
     import scala.collection.JavaConverters._
+
     override def tiType: TiType = TiType.tuple(
-      elements.map { case (e, _) => e.tiType } .asJava
+      elements.map { case (e, _) => e.tiType }.asJava
     )
 
     override def alias: CompositeYtLogicalTypeAlias = Tuple
+
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToStruct {
+      private val membersGetters = entries.zipWithIndex.map { case ((name, logicalType), i) =>
+        java.util.Map.entry(name, logicalType.ytGettersFromStruct(ytGetter, i))
+      }.asJava
+
+      override def getMembersGetters(): java.util.List[java.util.Map.Entry[String, ytGetter.FromStruct]] = membersGetters
+
+      override def getStruct(list: ArrayData, i: Int): InternalRow = list.getStruct(i, elements.size)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit = {
+        val value = list.getStruct(i, membersGetters.size())
+        ysonConsumer.onBeginList()
+        membersGetters.forEach { getter =>
+          ysonConsumer.onListItem()
+          getter.getValue.getYson(value, ysonConsumer)
+        }
+        ysonConsumer.onEndList()
+      }
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToStruct {
+      private val membersGetters = entries.zipWithIndex.map { case ((name, logicalType), i) =>
+        java.util.Map.entry(name, logicalType.ytGettersFromStruct(ytGetter, i))
+      }.asJava
+
+      override def getMembersGetters(): java.util.List[java.util.Map.Entry[String, ytGetter.FromStruct]] = membersGetters
+
+      override def getStruct(struct: InternalRow): InternalRow = struct.getStruct(ordinal, elements.size)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit = {
+        val value = struct.getStruct(ordinal, membersGetters.size())
+        ysonConsumer.onBeginList()
+        membersGetters.forEach { getter =>
+          ysonConsumer.onListItem()
+          getter.getValue.getYson(value, ysonConsumer)
+        }
+        ysonConsumer.onEndList()
+      }
+    }
   }
 
   case object Tuple extends CompositeYtLogicalTypeAlias(TypeName.Tuple.getWireName)
@@ -223,34 +1043,103 @@ object YtLogicalType {
     override def tiType: TiType = TiType.tagged(inner.tiType, tag)
 
     override def alias: CompositeYtLogicalTypeAlias = Tagged
+
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = inner.ytGettersFromList(ytGetter)
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = inner.ytGettersFromStruct(ytGetter, ordinal)
   }
 
   case object Tagged extends CompositeYtLogicalTypeAlias(TypeName.Tagged.getWireName)
 
+  private class VariantGetter(fields: Seq[YtLogicalType], ytGetter: InternalRowYTGetters) {
+    private val getters = fields.zipWithIndex.map { case (field, i) => field.ytGettersFromStruct(ytGetter, i) }
+
+    def get(row: InternalRow, ysonConsumer: YsonConsumer): Unit = {
+      val notNulls = (0 until row.numFields).filter(!row.isNullAt(_))
+      if (notNulls.isEmpty) {
+        throw new IllegalArgumentException("All elements in variant is null")
+      } else if (notNulls.size > 1) {
+        throw new IllegalArgumentException("Not null element must be single")
+      } else {
+        val index = notNulls.head
+        ysonConsumer.onBeginList()
+        ysonConsumer.onListItem()
+        ysonConsumer.onInteger(index)
+        ysonConsumer.onListItem()
+        getters(index).getYson(row, ysonConsumer)
+        ysonConsumer.onEndList()
+      }
+    }
+  }
+
   case class VariantOverStruct(fields: Seq[(String, YtLogicalType, Metadata)]) extends CompositeYtLogicalType {
     override def sparkType: SparkType = SingleSparkType(StructType(fields.map { case (name, ytType, meta) =>
-      getStructField(s"_v$name", ytType, meta, forcedNullability = Some(true), topLevel = false) }))
+      getStructField(s"_v$name", ytType, meta, forcedNullability = Some(true), topLevel = false)
+    }))
 
     import scala.collection.JavaConverters._
+
     override def tiType: TiType = TiType.variantOverStruct(
-      fields.map{ case (name, ytType, _) => new Member(name, ytType.tiType)}.asJava
+      fields.map { case (name, ytType, _) => new Member(name, ytType.tiType) }.asJava
     )
 
     override def alias: CompositeYtLogicalTypeAlias = Variant
+
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToYson {
+      val getter = new VariantGetter(fields.map(_._2), ytGetter)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        getter.get(list.getStruct(i, fields.size), ysonConsumer)
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToYson {
+      val getter = new VariantGetter(fields.map(_._2), ytGetter)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        getter.get(struct.getStruct(ordinal, fields.size), ysonConsumer)
+    }
   }
 
   case class VariantOverTuple(fields: Seq[(YtLogicalType, Metadata)]) extends CompositeYtLogicalType {
     override def sparkType: SparkType = SingleSparkType(
       StructType(fields.zipWithIndex.map { case ((ytType, meta), index) =>
-        getStructField(s"_v_${1 + index}", ytType, meta, forcedNullability = Some(true), topLevel = false) })
+        getStructField(s"_v_${1 + index}", ytType, meta, forcedNullability = Some(true), topLevel = false)
+      })
     )
 
     import scala.collection.JavaConverters._
+
     override def tiType: TiType = TiType.variantOverTuple(
       fields.map { case (e, _) => e.tiType }.asJava
     )
 
     override def alias: CompositeYtLogicalTypeAlias = Variant
+
+    override def ytGettersFromList(ytGetter: InternalRowYTGetters): ytGetter.FromList = new ytGetter.FromListToYson {
+      val getter = new VariantGetter(fields.map(_._1), ytGetter)
+
+      override def getSize(list: ArrayData): Int = list.numElements()
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(list: ArrayData, i: Int, ysonConsumer: YsonConsumer): Unit =
+        getter.get(list.getStruct(i, fields.size), ysonConsumer)
+    }
+
+    override def ytGettersFromStruct(ytGetter: InternalRowYTGetters, ordinal: Int): ytGetter.FromStruct = new ytGetter.FromStructToYson {
+      val getter = new VariantGetter(fields.map(_._1), ytGetter)
+
+      override def getTiType: TiType = tiType
+
+      override def getYson(struct: InternalRow, ysonConsumer: YsonConsumer): Unit =
+        getter.get(struct.getStruct(ordinal, fields.size), ysonConsumer)
+    }
   }
 
   case object Variant extends CompositeYtLogicalTypeAlias(TypeName.Variant.getWireName)

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YtLogicalTypeSerializer.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serializers/YtLogicalTypeSerializer.scala
@@ -1,6 +1,6 @@
 package tech.ytsaurus.spyt.serializers
 
-import org.apache.spark.sql.types.Metadata
+import org.apache.spark.sql.types.{DecimalType, Metadata}
 import tech.ytsaurus.ysontree.{YTree, YTreeBuilder, YTreeMapNode, YTreeNode, YTreeStringNode}
 
 import scala.collection.JavaConverters.asScalaBufferConverter
@@ -105,10 +105,8 @@ object YtLogicalTypeSerializer {
         case YtLogicalType.Optional =>
           YtLogicalType.Optional(deserializeTypeV3(m.getOrThrow("item")))
         case YtLogicalType.Decimal =>
-          YtLogicalType.Decimal(
-            m.getOrThrow("precision").intValue(),
-            m.getOrThrow("scale").intValue()
-          )
+          val decimalType = DecimalType(m.getOrThrow("precision").intValue(), m.getOrThrow("scale").intValue())
+          YtLogicalType.Decimal(decimalType.precision, decimalType.scale, decimalType)
         case YtLogicalType.Dict =>
           YtLogicalType.Dict(
             deserializeTypeV3(m.getOrThrow("key")),


### PR DESCRIPTION
Summary:

* `YTGetters<Row, List, Dict>` is a new interface, which is going to be pushed to the YT-client. It works as a typeclass, while implementations of its inner abstract classes are responsible for adapting rows to the YT types. The typeclass thing did not work out so well, so I will probably rewrite this by pushing the generic parameters down to each abstract class and making them static.
* `ArrowTableRowsSerializer` is an implementation of writing YT-data via Apache Arrow protocol. The data is being received using the YT-getters. This is also supposed to be moved to the YT-client at some point.
* `TableWriterBaseImpl` is copied from the YT-client to shadow the original class and patched to extend it with new functionality. Also is supposed to be moved to the YT-client.
* `YTLogicalType` interfaces are extended with methods providing `YTGetters` implementations, mapping Spark data to YT. This part is supposed to stay in our repository.

All tests in `ComplexTypeV3Test`, except the ones about the nested dates, are working. We will need to wait for a fix in YT-storage for that – https://github.com/ytsaurus/ytsaurus/pull/942/files