### PR TITLE
Separate proxy role into client (spark.hadoop.yt.proxyRole) and cluster (spark.hadoop.yt.clusterProxyRole)

### DIFF
--- a/resource-manager/src/main/scala/org/apache/spark/deploy/ytsaurus/YTsaurusClusterApplication.scala
+++ b/resource-manager/src/main/scala/org/apache/spark/deploy/ytsaurus/YTsaurusClusterApplication.scala
@@ -20,9 +20,13 @@ private[spark] class YTsaurusClusterApplication extends SparkApplication with Lo
   override def start(args: Array[String], conf: SparkConf): Unit = {
     val masterURL = conf.get("spark.master")
     val ytProxy = YTsaurusUtils.parseMasterUrl(masterURL)
+    val proxyRole = conf.getOption("spark.hadoop.yt.proxyRole")
     val networkName = conf.getOption("spark.hadoop.yt.proxyNetworkName")
     if (conf.contains("spark.hadoop.yt.clusterProxy")) {
       conf.set("spark.hadoop.yt.proxy", conf.get("spark.hadoop.yt.clusterProxy"))
+    }
+    if (conf.contains("spark.hadoop.yt.clusterProxyRole")) {
+      conf.set("spark.hadoop.yt.proxyRole", conf.get("spark.hadoop.yt.clusterProxyRole"))
     }
 
     val appArgs = ApplicationArguments.fromCommandLineArgs(args)
@@ -30,7 +34,7 @@ private[spark] class YTsaurusClusterApplication extends SparkApplication with Lo
     logInfo(s"Submitting spark application to YTsaurus cluster at $ytProxy")
     logInfo(s"Application arguments: $appArgs")
 
-    val operationManager = YTsaurusOperationManager.create(ytProxy, conf, networkName)
+    val operationManager = YTsaurusOperationManager.create(ytProxy, conf, networkName, proxyRole)
 
     try {
       val driverOperation = operationManager.startDriver(conf, appArgs)

--- a/resource-manager/src/main/scala/org/apache/spark/scheduler/cluster/ytsaurus/YTsaurusClusterManager.scala
+++ b/resource-manager/src/main/scala/org/apache/spark/scheduler/cluster/ytsaurus/YTsaurusClusterManager.scala
@@ -24,16 +24,23 @@ private[spark] class YTsaurusClusterManager extends ExternalClusterManager with 
     logInfo("Creating YTsaurus scheduler backend")
     var ytProxy = YTsaurusUtils.parseMasterUrl(masterURL)
     val deployMode = sc.conf.get("spark.submit.deployMode")
+    var proxyRole = sc.conf.getOption("spark.hadoop.yt.proxyRole")
     var networkName = sc.conf.getOption("spark.hadoop.yt.proxyNetworkName")
     if (deployMode == "cluster") {
       ytProxy = sc.conf.get("spark.hadoop.yt.clusterProxy", ytProxy)
+      if (sc.conf.contains("spark.hadoop.yt.clusterProxyRole")) {
+        proxyRole = sc.conf.getOption("spark.hadoop.yt.clusterProxyRole")
+      }
       networkName = None
     }
     if (sc.conf.contains("spark.hadoop.yt.clusterProxy")) {
       sc.conf.set("spark.hadoop.yt.proxy", sc.conf.get("spark.hadoop.yt.clusterProxy"))
     }
+    if (sc.conf.contains("spark.hadoop.yt.clusterProxyRole")) {
+      sc.conf.set("spark.hadoop.yt.proxyRole", sc.conf.get("spark.hadoop.yt.clusterProxyRole"))
+    }
 
-    val operationManager = YTsaurusOperationManager.create(ytProxy, sc.conf, networkName)
+    val operationManager = YTsaurusOperationManager.create(ytProxy, sc.conf, networkName, proxyRole)
 
     new YTsaurusSchedulerBackend(scheduler.asInstanceOf[TaskSchedulerImpl], sc, operationManager)
   }

--- a/resource-manager/src/main/scala/org/apache/spark/scheduler/cluster/ytsaurus/YTsaurusOperationManager.scala
+++ b/resource-manager/src/main/scala/org/apache/spark/scheduler/cluster/ytsaurus/YTsaurusOperationManager.scala
@@ -284,9 +284,8 @@ private[spark] class YTsaurusOperationManager(val ytClient: YTsaurusClient,
 
 private[spark] object YTsaurusOperationManager extends Logging {
 
-  def create(ytProxy: String, conf: SparkConf, networkName: Option[String]): YTsaurusOperationManager = {
+  def create(ytProxy: String, conf: SparkConf, networkName: Option[String], proxyRole: Option[String]): YTsaurusOperationManager = {
     val (user, token) = YTsaurusUtils.userAndToken(conf)
-    val proxyRole = conf.getOption("spark.hadoop.yt.proxyRole")
     val ytClient: YTsaurusClient = buildClient(ytProxy, user, token, networkName, proxyRole)
 
     try {


### PR DESCRIPTION
Separate proxy role into client (spark.hadoop.yt.proxyRole) and cluster (spark.hadoop.yt.clusterProxyRole)