### PR TITLE
spark.hadoop.yt.fqdn.enabled

### DIFF
--- a/spark-cluster/src/main/scala/tech/ytsaurus/spark/launcher/VanillaLauncher.scala
+++ b/spark-cluster/src/main/scala/tech/ytsaurus/spark/launcher/VanillaLauncher.scala
@@ -8,15 +8,7 @@ import scala.util.{Failure, Success, Try}
 trait VanillaLauncher {
   lazy val home: String = new File(sys.env.getOrElse("HOME", ".")).getAbsolutePath
 
-  lazy val sparkSystemProperties: Map[String, String] = {
-    import scala.collection.JavaConverters._
-    System.getProperties
-      .stringPropertyNames().asScala
-      .collect {
-        case name if name.startsWith("spark.") => name -> System.getProperty(name)
-      }
-      .toMap
-  }
+  val sparkSystemProperties: Map[String, String] = tech.ytsaurus.spyt.wrapper.Utils.sparkSystemProperties
 
   val sparkHome: String = new File(env("SPARK_HOME", "./spark")).getAbsolutePath
   val spytHome: String = new File(env("SPYT_HOME", "./spyt-package")).getAbsolutePath

--- a/spyt-package/src/main/python/spyt/enabler.py
+++ b/spyt-package/src/main/python/spyt/enabler.py
@@ -13,12 +13,11 @@ class SpytEnablers(object):
     MTN_KEY = "spark.hadoop.yt.mtn.enabled"
     SOLOMON_AGENT_KEY = "spark.hadoop.yt.solomonAgent.enabled"
     IPV6_KEY = "spark.hadoop.yt.preferenceIpv6.enabled"
-    FQDN_KEY = "spark.hadoop.yt.fqdn.enabled"
     TCP_PROXY_KEY = "spark.hadoop.yt.tcpProxy.enabled"
     SQUASHFS_KEY = "spark.ytsaurus.squashfs.enabled"
 
     def __init__(self, enable_byop=False, enable_profiling=False, enable_arrow=True,
-                 enable_mtn=False, enable_solomon_agent=True, enable_preference_ipv6=True, enable_fqdn=False,
+                 enable_mtn=False, enable_solomon_agent=True, enable_preference_ipv6=True,
                  enable_tcp_proxy=False, enable_squashfs=False):
         self.enable_byop = enable_byop
         self.enable_profiling = enable_profiling
@@ -26,7 +25,6 @@ class SpytEnablers(object):
         self.enable_mtn = enable_mtn
         self.enable_solomon_agent = enable_solomon_agent
         self.enable_preference_ipv6 = enable_preference_ipv6
-        self.enable_fqdn = enable_fqdn
         self.enable_tcp_proxy = enable_tcp_proxy
         self.enable_squashfs = enable_squashfs
         self.config_enablers = {}
@@ -49,7 +47,6 @@ class SpytEnablers(object):
         self.enable_mtn = self._get_enabler(self.enable_mtn, "enable_mtn", self.MTN_KEY)
         self.enable_solomon_agent = self._get_enabler(self.enable_solomon_agent, "enable_solomon_agent",
                                                       self.SOLOMON_AGENT_KEY)
-        self.enable_fqdn = self._get_enabler(self.enable_fqdn, "enable_fqdn", self.FQDN_KEY)
         self.enable_tcp_proxy = self._get_enabler(self.enable_tcp_proxy, "enable_tcp_proxy", self.TCP_PROXY_KEY)
         self.enable_squashfs = self._get_enabler(self.enable_squashfs, "enable_squashfs", self.SQUASHFS_KEY)
 
@@ -61,5 +58,4 @@ class SpytEnablers(object):
             self.BYOP_KEY: str(self.enable_byop),
             self.ARROW_KEY: str(self.enable_arrow),
             self.IPV6_KEY: str(self.enable_preference_ipv6),
-            self.FQDN_KEY: str(self.enable_fqdn),
         }

--- a/spyt-package/src/main/python/spyt/enabler.py
+++ b/spyt-package/src/main/python/spyt/enabler.py
@@ -13,11 +13,12 @@ class SpytEnablers(object):
     MTN_KEY = "spark.hadoop.yt.mtn.enabled"
     SOLOMON_AGENT_KEY = "spark.hadoop.yt.solomonAgent.enabled"
     IPV6_KEY = "spark.hadoop.yt.preferenceIpv6.enabled"
+    FQDN_KEY = "spark.hadoop.yt.fqdn.enabled"
     TCP_PROXY_KEY = "spark.hadoop.yt.tcpProxy.enabled"
     SQUASHFS_KEY = "spark.ytsaurus.squashfs.enabled"
 
     def __init__(self, enable_byop=False, enable_profiling=False, enable_arrow=True,
-                 enable_mtn=False, enable_solomon_agent=True, enable_preference_ipv6=True,
+                 enable_mtn=False, enable_solomon_agent=True, enable_preference_ipv6=True, enable_fqdn=False,
                  enable_tcp_proxy=False, enable_squashfs=False):
         self.enable_byop = enable_byop
         self.enable_profiling = enable_profiling
@@ -25,6 +26,7 @@ class SpytEnablers(object):
         self.enable_mtn = enable_mtn
         self.enable_solomon_agent = enable_solomon_agent
         self.enable_preference_ipv6 = enable_preference_ipv6
+        self.enable_fqdn = enable_fqdn
         self.enable_tcp_proxy = enable_tcp_proxy
         self.enable_squashfs = enable_squashfs
         self.config_enablers = {}
@@ -47,6 +49,7 @@ class SpytEnablers(object):
         self.enable_mtn = self._get_enabler(self.enable_mtn, "enable_mtn", self.MTN_KEY)
         self.enable_solomon_agent = self._get_enabler(self.enable_solomon_agent, "enable_solomon_agent",
                                                       self.SOLOMON_AGENT_KEY)
+        self.enable_fqdn = self._get_enabler(self.enable_fqdn, "enable_fqdn", self.FQDN_KEY)
         self.enable_tcp_proxy = self._get_enabler(self.enable_tcp_proxy, "enable_tcp_proxy", self.TCP_PROXY_KEY)
         self.enable_squashfs = self._get_enabler(self.enable_squashfs, "enable_squashfs", self.SQUASHFS_KEY)
 
@@ -58,4 +61,5 @@ class SpytEnablers(object):
             self.BYOP_KEY: str(self.enable_byop),
             self.ARROW_KEY: str(self.enable_arrow),
             self.IPV6_KEY: str(self.enable_preference_ipv6),
+            self.FQDN_KEY: str(self.enable_fqdn),
         }

--- a/yt-wrapper/src/main/scala/tech/ytsaurus/spyt/wrapper/Utils.scala
+++ b/yt-wrapper/src/main/scala/tech/ytsaurus/spyt/wrapper/Utils.scala
@@ -46,7 +46,7 @@ object Utils {
   def ytHostnameOrIpAddress: String =
     if (ytNetworkProjectEnabled)
       ytHostIp
-    else if (sparkSystemProperties.get("spark.yt.use_fqdn").exists(_.toBoolean))
+    else if (sparkSystemProperties.get("spark.yt.useFqdn").exists(_.toBoolean))
       InetAddress.getLocalHost.getCanonicalHostName
     else
       InetAddress.getLocalHost.getHostName


### PR DESCRIPTION
Similarly to `spark.hadoop.yt.preferenceIpv6.enabled`:
https://github.com/ytsaurus/ytsaurus-spyt/blob/c2256423d8d05eb7b3f275afbee9866f0fccc6c1/spark-cluster/src/main/scala/tech/ytsaurus/spark/launcher/SparkLauncher.scala#L85