### PR TITLE
log4j2 should use thread-safe JsonTemplateLayout

### DIFF
--- a/spark-cluster/src/main/scala/tech/ytsaurus/spark/launcher/VanillaLauncher.scala
+++ b/spark-cluster/src/main/scala/tech/ytsaurus/spark/launcher/VanillaLauncher.scala
@@ -63,6 +63,7 @@ trait VanillaLauncher {
 
   def log4jConfigJavaOption(logJson: Boolean): String = {
     val log4jProperties = if (logJson) "log4j.clusterLogJson.properties" else "log4j.clusterLog.properties"
-    s"-Dlog4j.configuration=file://$spytHome/conf/$log4jProperties"
+    val log4j2Properties = if (logJson) "log4j2.clusterLogJson.properties" else "log4j2.clusterLog.properties"
+    s"-Dlog4j.configuration=file://$spytHome/conf/$log4jProperties -Dlog4j2.configurationFile=file://$spytHome/conf/$log4j2Properties"
   }
 }

--- a/spyt-package/src/main/spark-extra/conf/log4j2.clusterLog.properties
+++ b/spyt-package/src/main/spark-extra/conf/log4j2.clusterLog.properties
@@ -1,0 +1,40 @@
+rootLogger.level=INFO
+rootLogger.appenderRef.0.ref=console
+
+appender.console.type=Console
+appender.console.target=SYSTEM_ERR
+appender.console.layout.type=PatternLayout
+appender.console.layout.pattern=%d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+
+# Set the default spark-shell log level to WARN. When running the spark-shell, the
+# log level for this class is used to overwrite the root logger's log level, so that
+# the user can have different defaults for the shell and regular Spark apps.
+logger.repl.name=org.apache.spark.repl.Main
+logger.repl.level=warn
+
+# Settings to quiet third party logs that are too verbose
+logger.jetty1.name=org.sparkproject.jetty
+logger.jetty1.level=warn
+logger.jetty2.name=org.sparkproject.jetty.util.component.AbstractLifeCycle
+logger.jetty2.level=error
+logger.repl_expr_typer.name=org.apache.spark.repl.SparkIMain$exprTyper
+logger.repl_expr_typer.level=info
+logger.repl_loop_interpreter.name=org.apache.spark.repl.SparkILoop$SparkILoopInterpreter
+logger.repl_loop_interpreter.level=info
+logger.parquet1.name=org.apache.parquet
+logger.parquet1.level=error
+logger.parquet2.name=parquet
+logger.parquet2.level=error
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+logger.RetryingHMSHandler.name=org.apache.hadoop.hive.metastore.RetryingHMSHandler
+logger.RetryingHMSHandler.level=fatal
+logger.FunctionRegistry.name=org.apache.hadoop.hive.ql.exec.FunctionRegistry
+logger.FunctionRegistry.level=error
+
+logger.spyt_launcher.name=tech.ytsaurus.spark.launcher
+logger.spyt_launcher.level=debug
+
+logger.spark.name=org.apache.spark
+logger.spark.level=info
+logger.spark.appenderRef.0.ref=console

--- a/spyt-package/src/main/spark-extra/conf/log4j2.clusterLogJson.properties
+++ b/spyt-package/src/main/spark-extra/conf/log4j2.clusterLogJson.properties
@@ -1,0 +1,39 @@
+rootLogger.level=INFO
+rootLogger.appenderRef.0.ref=console
+
+appender.console.type=Console
+appender.console.target=SYSTEM_ERR
+appender.console.layout.type=JsonTemplateLayout
+
+# Set the default spark-shell log level to WARN. When running the spark-shell, the
+# log level for this class is used to overwrite the root logger's log level, so that
+# the user can have different defaults for the shell and regular Spark apps.
+logger.repl.name=org.apache.spark.repl.Main
+logger.repl.level=warn
+
+# Settings to quiet third party logs that are too verbose
+logger.jetty1.name=org.sparkproject.jetty
+logger.jetty1.level=warn
+logger.jetty2.name=org.sparkproject.jetty.util.component.AbstractLifeCycle
+logger.jetty2.level=error
+logger.repl_expr_typer.name=org.apache.spark.repl.SparkIMain$exprTyper
+logger.repl_expr_typer.level=info
+logger.repl_loop_interpreter.name=org.apache.spark.repl.SparkILoop$SparkILoopInterpreter
+logger.repl_loop_interpreter.level=info
+logger.parquet1.name=org.apache.parquet
+logger.parquet1.level=error
+logger.parquet2.name=parquet
+logger.parquet2.level=error
+
+# SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
+logger.RetryingHMSHandler.name=org.apache.hadoop.hive.metastore.RetryingHMSHandler
+logger.RetryingHMSHandler.level=fatal
+logger.FunctionRegistry.name=org.apache.hadoop.hive.ql.exec.FunctionRegistry
+logger.FunctionRegistry.level=error
+
+logger.spyt_launcher.name=tech.ytsaurus.spark.launcher
+logger.spyt_launcher.level=debug
+
+logger.spark.name=org.apache.spark
+logger.spark.level=info
+logger.spark.appenderRef.0.ref=console


### PR DESCRIPTION
```
ERROR StatusConsoleListener An exception occurred processing Appender console
 java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1511)
	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1544)
	at java.base/java.util.HashMap$EntryIterator.next(HashMap.java:1542)
	at net.minidev.json.JSONObject.writeJSON(JSONObject.java:162)
	at net.minidev.json.JSONObject.toJSONString(JSONObject.java:72)
	at net.minidev.json.JSONObject.toString(JSONObject.java:261)
	at net.logstash.log4j.JSONEventLayoutV1.format(JSONEventLayoutV1.java:137)
	at org.apache.log4j.bridge.LayoutAdapter.toByteArray(LayoutAdapter.java:71)
	at org.apache.log4j.bridge.LayoutAdapter.encode(LayoutAdapter.java:92)
	at org.apache.log4j.bridge.LayoutAdapter.encode(LayoutAdapter.java:29)
	at org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.directEncodeEvent(AbstractOutputStreamAppender.java:215)
	at org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.tryAppend(AbstractOutputStreamAppender.java:208)
	at org.apache.logging.log4j.core.appender.AbstractOutputStreamAppender.append(AbstractOutputStreamAppender.java:199)
	at org.apache.logging.log4j.core.config.AppenderControl.tryCallAppender(AppenderControl.java:161)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender0(AppenderControl.java:134)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppenderPreventRecursion(AppenderControl.java:125)
	at org.apache.logging.log4j.core.config.AppenderControl.callAppender(AppenderControl.java:89)
	at org.apache.logging.log4j.core.config.LoggerConfig.callAppenders(LoggerConfig.java:683)
	at org.apache.logging.log4j.core.config.LoggerConfig.processLogEvent(LoggerConfig.java:641)
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:624)
	at org.apache.logging.log4j.core.config.LoggerConfig.log(LoggerConfig.java:560)
	at org.apache.logging.log4j.core.config.DefaultReliabilityStrategy.log(DefaultReliabilityStrategy.java:63)
	at org.apache.logging.log4j.core.Logger.log(Logger.java:163)
	at org.apache.logging.log4j.spi.AbstractLogger.tryLogMessage(AbstractLogger.java:2168)
	at org.apache.logging.log4j.spi.AbstractLogger.logMessageTrackRecursion(AbstractLogger.java:2122)
	at org.apache.logging.log4j.spi.AbstractLogger.logMessageSafely(AbstractLogger.java:2105)
	at org.apache.logging.log4j.spi.AbstractLogger.logMessage(AbstractLogger.java:1985)
	at org.apache.logging.log4j.spi.AbstractLogger.logIfEnabled(AbstractLogger.java:1838)
	at org.apache.logging.slf4j.Log4jLogger.info(Log4jLogger.java:175)
	at org.apache.spark.internal.Logging.logInfo(Logging.scala:60)
	at org.apache.spark.internal.Logging.logInfo$(Logging.scala:59)
	at org.apache.spark.scheduler.DAGScheduler.logInfo(DAGScheduler.scala:121)
	at org.apache.spark.scheduler.DAGScheduler.handleMapStageSubmitted(DAGScheduler.scala:1365)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:3007)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2994)
	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2983)
	at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:49)
```

