### PR TITLE
ListParser exceptions should contain parser context

### DIFF
--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serialization/ExceptionUtils.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serialization/ExceptionUtils.scala
@@ -9,6 +9,7 @@ object ExceptionUtils {
   class InterruptedRuntimeException(cause: Throwable) extends RuntimeException(cause)
   class ExecutionRuntimeException(cause: Throwable) extends RuntimeException(cause)
   class TimeoutRuntimeException(cause: Throwable) extends RuntimeException(cause)
+  class YsonParseException(index: Any, cause: Throwable) extends RuntimeException(s"Yson parse error at index $index", cause)
 
   def translate(e: Exception): RuntimeException = e match {
     case exception: RuntimeException => exception

--- a/data-source/src/main/scala/tech/ytsaurus/spyt/serialization/ListParser.scala
+++ b/data-source/src/main/scala/tech/ytsaurus/spyt/serialization/ListParser.scala
@@ -4,6 +4,7 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow
 import org.apache.spark.sql.catalyst.util.{ArrayBasedMapData, ArrayData}
 import org.apache.spark.sql.types.{StructField, StructType}
+import tech.ytsaurus.spyt.serialization.ExceptionUtils.YsonParseException
 import tech.ytsaurus.yson.YsonTags
 
 trait ListParser {
@@ -17,7 +18,7 @@ trait ListParser {
       try {
         res += parseNode(token, allowEof, elementType)
       } catch {
-        case e: Exception => throw new RuntimeException("" + index, e)
+        case e: Exception => throw new YsonParseException(index, e)
       }
     }
     ArrayData.toArrayData(res.result())
@@ -39,7 +40,7 @@ trait ListParser {
           fieldName, throw new NoSuchElementException(s"$fieldName is not found in schema map")
         ).dataType)
       } catch {
-        case e: Exception => throw new RuntimeException(fieldName, e)
+        case e: Exception => throw new YsonParseException(fieldName, e)
       }
     }
     new GenericInternalRow(res)
@@ -55,7 +56,7 @@ trait ListParser {
           parseNode(token, allowEof, IndexedDataType.NoneType)
         }
       } catch {
-        case e: Exception => throw new RuntimeException("" + index, e)
+        case e: Exception => throw new YsonParseException(index, e)
       }
     }
     res


### PR DESCRIPTION
Right now it is impossible to trace the problem even to the column.

```
java.lang.IllegalArgumentException: Unsupported data type: AtomicType(StringType) for yson list
	at tech.ytsaurus.spyt.serialization.YsonDecoder.parseWithoutAttributes(YsonDecoder.scala:192)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.parseNode(YsonDecoder.scala:125)
	at tech.ytsaurus.spyt.serialization.ListParser.$anonfun$parseYsonListAsSparkStruct$1(ListParser.scala:39)
	at tech.ytsaurus.spyt.serialization.ListParser.$anonfun$parseYsonListAsSparkStruct$1$adapted(ListParser.scala:33)
	at tech.ytsaurus.spyt.serialization.YsonBaseReader.read$1(YsonBaseReader.scala:28)
	at tech.ytsaurus.spyt.serialization.YsonBaseReader.readList(YsonBaseReader.scala:33)
	at tech.ytsaurus.spyt.serialization.YsonBaseReader.readList$(YsonBaseReader.scala:18)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.readList(YsonDecoder.scala:12)
	at tech.ytsaurus.spyt.serialization.ListParser.parseYsonListAsSparkStruct(ListParser.scala:33)
	at tech.ytsaurus.spyt.serialization.ListParser.parseYsonListAsSparkStruct$(ListParser.scala:31)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.parseYsonListAsSparkStruct(YsonDecoder.scala:12)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.parseWithoutAttributes(YsonDecoder.scala:186)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.parseNode(YsonDecoder.scala:125)
	at tech.ytsaurus.spyt.serialization.ListParser.$anonfun$parseYsonListAsSparkList$1(ListParser.scala:18)
	at tech.ytsaurus.spyt.serialization.ListParser.$anonfun$parseYsonListAsSparkList$1$adapted(ListParser.scala:17)
	at tech.ytsaurus.spyt.serialization.YsonBaseReader.read$1(YsonBaseReader.scala:28)
	at tech.ytsaurus.spyt.serialization.YsonBaseReader.readList(YsonBaseReader.scala:33)
	at tech.ytsaurus.spyt.serialization.YsonBaseReader.readList$(YsonBaseReader.scala:18)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.readList(YsonDecoder.scala:12)
	at tech.ytsaurus.spyt.serialization.ListParser.parseYsonListAsSparkList(ListParser.scala:17)
	at tech.ytsaurus.spyt.serialization.ListParser.parseYsonListAsSparkList$(ListParser.scala:15)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.parseYsonListAsSparkList(YsonDecoder.scala:12)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.parseWithoutAttributes(YsonDecoder.scala:184)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.parseNode(YsonDecoder.scala:125)
	at tech.ytsaurus.spyt.serialization.ListParser.$anonfun$parseYsonListAsSparkStruct$1(ListParser.scala:39)
	at tech.ytsaurus.spyt.serialization.ListParser.$anonfun$parseYsonListAsSparkStruct$1$adapted(ListParser.scala:33)
	at tech.ytsaurus.spyt.serialization.YsonBaseReader.read$1(YsonBaseReader.scala:28)
	at tech.ytsaurus.spyt.serialization.YsonBaseReader.readList(YsonBaseReader.scala:33)
	at tech.ytsaurus.spyt.serialization.YsonBaseReader.readList$(YsonBaseReader.scala:18)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.readList(YsonDecoder.scala:12)
	at tech.ytsaurus.spyt.serialization.ListParser.parseYsonListAsSparkStruct(ListParser.scala:33)
	at tech.ytsaurus.spyt.serialization.ListParser.parseYsonListAsSparkStruct$(ListParser.scala:31)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.parseYsonListAsSparkStruct(YsonDecoder.scala:12)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.parseWithoutAttributes(YsonDecoder.scala:186)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.parseNode(YsonDecoder.scala:125)
	at tech.ytsaurus.spyt.serialization.YsonDecoder.parseNode(YsonDecoder.scala:129)
	at tech.ytsaurus.spyt.serialization.YsonDecoder$.decode(YsonDecoder.scala:215)
	at tech.ytsaurus.spyt.serializers.WireDeserializer.onBytes(WireDeserializer.scala:149)
	at tech.ytsaurus.client.rows.WireProtocolReader.readValueImpl(WireProtocolReader.java:228)
	at tech.ytsaurus.client.rows.WireProtocolReader.readValue(WireProtocolReader.java:264)
	at tech.ytsaurus.client.rows.WireProtocolReader.readUnversionedValues(WireProtocolReader.java:195)
	at tech.ytsaurus.client.rows.WireProtocolReader.readUnversionedRow(WireProtocolReader.java:298)
	at tech.ytsaurus.client.TableAttachmentWireProtocolReader.parseMergedRow(TableAttachmentWireProtocolReader.java:34)
	at tech.ytsaurus.client.TableAttachmentRowsetReader.parseRowData(TableAttachmentRowsetReader.java:62)
	at tech.ytsaurus.client.TableAttachmentRowsetReader.parseRowsWithStatistics(TableAttachmentRowsetReader.java:92)
	at tech.ytsaurus.client.TableAttachmentRowsetReader.parse(TableAttachmentRowsetReader.java:114)
	at tech.ytsaurus.client.TableReaderBaseImpl.read(TableReaderImpl.java:77)
	at tech.ytsaurus.client.TableReaderImpl.read(TableReaderImpl.java:136)
	at tech.ytsaurus.spyt.wrapper.table.TableIterator.readNextBatch(TableIterator.scala:37)
	at tech.ytsaurus.spyt.wrapper.table.TableIterator.hasNext(TableIterator.scala:22)
	at org.apache.spark.sql.v2.YtPartitionReaderFactoryAdapter$$anon$3.nextKeyValue(YtPartitionReaderFactoryAdapter.scala:156)
	at org.apache.spark.sql.v2.YtPartitionReaderFactoryAdapter$$anon$1.next(YtPartitionReaderFactoryAdapter.scala:70)
	at org.apache.spark.sql.execution.datasources.v2.PartitionReaderWithPartitionValues.next(PartitionReaderWithPartitionValues.scala:49)
	at org.apache.spark.sql.execution.datasources.v2.PartitionedFileReader.next(FilePartitionReaderFactory.scala:58)
	at org.apache.spark.sql.execution.datasources.v2.FilePartitionReader.next(FilePartitionReader.scala:69)
```

