### PR TITLE
fix and test spark.ui.reverseProxy

### DIFF
--- a/e2e-test/common/cluster.py
+++ b/e2e-test/common/cluster.py
@@ -124,6 +124,16 @@ class SpytCluster(ClusterBase):
             yield session
 
 
+class ReverseProxySpytCluster(SpytCluster):
+    @staticmethod
+    def get_params():
+        params = SpytCluster.get_params()
+        spark_conf = params.setdefault("spark_conf", {})
+        spark_conf["spark.ui.reverseProxy"] = "true"
+        spark_conf["spark.ui.reverseProxyUrl"] = "https://some-host/some-path/"
+        return params
+
+
 class LivyServer(ClusterBase):
     def __init__(self, proxy, discovery_path=None, group_id=None, yt_root_path=None, master_address=None,
                  dump_dir=None):

--- a/e2e-test/tests/conftest.py
+++ b/e2e-test/tests/conftest.py
@@ -1,6 +1,6 @@
 import spyt
 
-from common.cluster import DirectSubmitter, HistoryServer, LivyServer, SpytCluster, direct_spark_session
+from common.cluster import DirectSubmitter, HistoryServer, LivyServer, SpytCluster, ReverseProxySpytCluster, direct_spark_session
 from common.cluster_utils import default_conf
 import logging
 import os
@@ -31,6 +31,12 @@ def yt_client():
 @pytest.fixture(scope="function")
 def spyt_cluster(request):
     with SpytCluster(proxy=YT_PROXY, dump_dir=test_directory(request)) as cluster:
+        yield cluster
+
+
+@pytest.fixture(scope="function")
+def reverse_proxy_spyt_cluster(request):
+    with ReverseProxySpytCluster(proxy=YT_PROXY, dump_dir=test_directory(request)) as cluster:
         yield cluster
 
 

--- a/e2e-test/tests/test_cluster.py
+++ b/e2e-test/tests/test_cluster.py
@@ -10,8 +10,18 @@ def test_cluster_startup(yt_client, spyt_cluster):
     assert_items_equal(yt_client.list(spyt_cluster.discovery_path),
                        ["discovery", "logs"])
     assert_items_equal(yt_client.list(spyt_cluster.discovery_path + "/discovery"),
-                       ["conf", "master_wrapper", "operation", "rest", "spark_address", "version", "webui", "webui_url"])
+                       ["conf", "master_wrapper", "operation", "rest", "spark_address", "version", "webui", "master_jobs"])
 
+
+def test_reverse_proxy_cluster_startup(yt_client, reverse_proxy_spyt_cluster):
+    assert_items_equal(yt_client.list(reverse_proxy_spyt_cluster.discovery_path),
+                       ["discovery", "logs"])
+    assert_items_equal(yt_client.list(reverse_proxy_spyt_cluster.discovery_path + "/discovery"),
+                       ["conf", "master_wrapper", "operation", "rest", "spark_address", "version", "webui", "master_jobs"])
+    job_id = yt_client.list(reverse_proxy_spyt_cluster.discovery_path + "/discovery/master_jobs")[0]
+    assert yt_client.get(reverse_proxy_spyt_cluster.discovery_path + f"/discovery/master_jobs/{job_id}") == {
+        "webui_url": "https://some-host/some-path/"
+    }
 
 def test_prometheus_endpoint(yt_client, spyt_cluster):
     webui_endpoint = yt_client.list(spyt_cluster.discovery_path + "/discovery/webui")[0]

--- a/spyt-package/src/main/bin/spark-discovery-yt
+++ b/spyt-package/src/main/bin/spark-discovery-yt
@@ -16,7 +16,7 @@ def main(raw_args=None):
     client = YtClient(proxy=args.proxy, token=spark_utils.default_token())
     spark_cluster = find_spark_cluster(discovery_path=args.discovery_path, client=client)
     print("Master: {}".format(spark_cluster.master_endpoint))
-    print("Master Web UI: {}".format(spark_cluster.master_web_ui_schemed_url or "http://{}/".format(spark_cluster.master_web_ui_url)))
+    print("Master Web UI: {}".format(spark_cluster.master_web_ui()))
     print("Master REST API Endpoint: {}".format(spark_cluster.master_rest_endpoint))
     print("Operation: {}".format(spark_cluster.operation_url(client=client)))
     for url in spark_cluster.children_operation_urls(client=client):

--- a/spyt-package/src/main/bin/spark-discovery-yt
+++ b/spyt-package/src/main/bin/spark-discovery-yt
@@ -16,7 +16,7 @@ def main(raw_args=None):
     client = YtClient(proxy=args.proxy, token=spark_utils.default_token())
     spark_cluster = find_spark_cluster(discovery_path=args.discovery_path, client=client)
     print("Master: {}".format(spark_cluster.master_endpoint))
-    print("Master Web UI: {}".format(spark_cluster.master_web_ui()))
+    print("Master Web UI: {}".format(spark_cluster.master_webui()))
     print("Master REST API Endpoint: {}".format(spark_cluster.master_rest_endpoint))
     print("Operation: {}".format(spark_cluster.operation_url(client=client)))
     for url in spark_cluster.children_operation_urls(client=client):

--- a/spyt-package/src/main/python/spyt/standalone.py
+++ b/spyt-package/src/main/python/spyt/standalone.py
@@ -8,7 +8,7 @@ from spyt.dependency_utils import require_yt_client
 
 require_yt_client()
 
-from yt.wrapper.cypress_commands import exists, copy as cypress_copy, get as yt_get, list as yt_list  # noqa: E402
+from yt.wrapper.cypress_commands import exists, copy as cypress_copy, get as yt_get  # noqa: E402
 from yt.wrapper.acl_commands import check_permission  # noqa: E402
 from yt.wrapper.file_commands import upload_file_to_cache  # noqa: E402
 from yt.wrapper.http_helpers import get_token, get_user_name  # noqa: E402
@@ -668,7 +668,7 @@ def find_spark_cluster(discovery_path=None, client=None):
     """
     discovery = SparkDiscovery(discovery_path=discovery_path)
     master_jobs_path = discovery.discovery().join("master_jobs")
-    master_jobs = yt_list(master_jobs_path, client=client)
+    master_jobs = SparkDiscovery.getOptions(master_jobs_path, client=client)
     master_job = yt_get(master_jobs_path.join(master_jobs[0]), client=client) if master_jobs else None
     return SparkCluster(
         master_endpoint=SparkDiscovery.getOption(discovery.master_spark(), client=client),

--- a/spyt-package/src/main/python/spyt/standalone.py
+++ b/spyt-package/src/main/python/spyt/standalone.py
@@ -642,7 +642,7 @@ def start_spark_cluster(worker_cores, worker_memory, worker_num, worker_cores_ov
             _wait_child_start(op_driver, spark_discovery, client)
             logger.info("Driver operation %s", op_driver.id)
 
-        logger.info("Spark Master's Web UI: {0}".format(find_spark_cluster(discovery_path, client).master_web_ui()))
+        logger.info("Spark Master's Web UI: {0}".format(find_spark_cluster(discovery_path, client).master_webui()))
         return op
     except Exception as err:
         logging.error(err, exc_info=True)

--- a/spyt-package/src/main/python/spyt/utils.py
+++ b/spyt-package/src/main/python/spyt/utils.py
@@ -33,6 +33,9 @@ class SparkCluster(object):
         self.spark_cluster_version = spark_cluster_version
         self.children_operation_ids = children_operation_ids
 
+    def master_web_ui(self):
+        return self.master_web_ui_schemed_url or "http://{}/".format(self.master_web_ui_url)
+
     def operation_url(self, client=None):
         return get_operation_url(self.operation_id, client=client)
 
@@ -105,9 +108,6 @@ class SparkDiscovery(object):
 
     def master_webui(self):
         return self.discovery().join("webui")
-
-    def master_webui_url(self):
-        return self.discovery().join("webui_url")
 
     def master_rest(self):
         return self.discovery().join("rest")

--- a/spyt-package/src/main/python/spyt/utils.py
+++ b/spyt-package/src/main/python/spyt/utils.py
@@ -33,7 +33,7 @@ class SparkCluster(object):
         self.spark_cluster_version = spark_cluster_version
         self.children_operation_ids = children_operation_ids
 
-    def master_web_ui(self):
+    def master_webui(self):
         return self.master_web_ui_schemed_url or "http://{}/".format(self.master_web_ui_url)
 
     def operation_url(self, client=None):

--- a/yt-wrapper/src/test/scala/tech/ytsaurus/spyt/wrapper/cypress/YtCypressUtilsTest.scala
+++ b/yt-wrapper/src/test/scala/tech/ytsaurus/spyt/wrapper/cypress/YtCypressUtilsTest.scala
@@ -19,7 +19,7 @@ class YtCypressUtilsTest extends FlatSpec with Matchers with LocalYtClient with 
       new YTreeBuilder().beginMap().key("a").value(t.a).key("b").value(t.b).endMap().build()
     }
 
-    YtWrapper.createDocumentFromProduct(tmpPath, new TestDoc("A", 1))
+    YtWrapper.createDocumentFromProduct(tmpPath, TestDoc("A", 1))
 
     val res = YtWrapper.readDocument(tmpPath).asMap()
     res.keySet().asScala should contain theSameElementsAs Seq("a", "b")
@@ -60,7 +60,7 @@ class YtCypressUtilsTest extends FlatSpec with Matchers with LocalYtClient with 
     implicit val ysonWriter: YsonWriter[TestDoc] = (t: TestDoc) => {
       new YTreeBuilder().beginMap().key("a").value(t.a).key("b").value(t.b).endMap().build()
     }
-    YtWrapper.createDocumentFromProduct(tmpPath, new TestDoc("A", 1))
+    YtWrapper.createDocumentFromProduct(tmpPath, TestDoc("A", 1))
     YtWrapper.isDir(tmpPath) shouldBe false
   }
 
@@ -86,7 +86,7 @@ class YtCypressUtilsTest extends FlatSpec with Matchers with LocalYtClient with 
     }
     val tmpPath2 = s"$testDir/test-${UUID.randomUUID()}"
     try {
-      YtWrapper.createDocumentFromProduct(tmpPath, new TestDoc("A", 1))
+      YtWrapper.createDocumentFromProduct(tmpPath, TestDoc("A", 1))
       YtWrapper.createLink(tmpPath, tmpPath2)
       YtWrapper.readDocument(tmpPath2).asMap().getOrThrow("a").stringValue() shouldEqual "A"
     }

--- a/yt-wrapper/src/test/scala/tech/ytsaurus/spyt/wrapper/cypress/YtCypressUtilsTest.scala
+++ b/yt-wrapper/src/test/scala/tech/ytsaurus/spyt/wrapper/cypress/YtCypressUtilsTest.scala
@@ -19,7 +19,7 @@ class YtCypressUtilsTest extends FlatSpec with Matchers with LocalYtClient with 
       new YTreeBuilder().beginMap().key("a").value(t.a).key("b").value(t.b).endMap().build()
     }
 
-    YtWrapper.createDocument(tmpPath, new TestDoc("A", 1))
+    YtWrapper.createDocumentFromProduct(tmpPath, new TestDoc("A", 1))
 
     val res = YtWrapper.readDocument(tmpPath).asMap()
     res.keySet().asScala should contain theSameElementsAs Seq("a", "b")
@@ -60,7 +60,7 @@ class YtCypressUtilsTest extends FlatSpec with Matchers with LocalYtClient with 
     implicit val ysonWriter: YsonWriter[TestDoc] = (t: TestDoc) => {
       new YTreeBuilder().beginMap().key("a").value(t.a).key("b").value(t.b).endMap().build()
     }
-    YtWrapper.createDocument(tmpPath, new TestDoc("A", 1))
+    YtWrapper.createDocumentFromProduct(tmpPath, new TestDoc("A", 1))
     YtWrapper.isDir(tmpPath) shouldBe false
   }
 
@@ -86,7 +86,7 @@ class YtCypressUtilsTest extends FlatSpec with Matchers with LocalYtClient with 
     }
     val tmpPath2 = s"$testDir/test-${UUID.randomUUID()}"
     try {
-      YtWrapper.createDocument(tmpPath, new TestDoc("A", 1))
+      YtWrapper.createDocumentFromProduct(tmpPath, new TestDoc("A", 1))
       YtWrapper.createLink(tmpPath, tmpPath2)
       YtWrapper.readDocument(tmpPath2).asMap().getOrThrow("a").stringValue() shouldEqual "A"
     }
@@ -108,6 +108,6 @@ class YtCypressUtilsTest extends FlatSpec with Matchers with LocalYtClient with 
   }
 }
 
-class TestDoc(val a: String, val b: Int)
+case class TestDoc(a: String, b: Int)
 
 case class TestDocProduct(a: String, b: Int)


### PR DESCRIPTION
Continuing https://github.com/ytsaurus/ytsaurus-spyt/pull/74/files
Current approach with storing things in node names was faulty:

```
java.lang.IllegalArgumentException: Invalid path format: empty path component detected in '//home/faucct/spyt-discovery_path/discovery/webui_url/https:\/\/71a7b51f-1b2245a5-270703e8-3c227434-master-1.operation-id-task-name-port-id....\/'. Path components must not be empty (no consecutive '/' characters allowed)
```

Fixed this, covered with a test and also fixed the URL in message of `spark-launch-yt`.